### PR TITLE
added optional branchortag parameter to ListCommits on commits resource

### DIFF
--- a/SharpBucket/Properties/AssemblyInfo.cs
+++ b/SharpBucket/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.1.0")]
-[assembly: AssemblyFileVersion("0.4.1.0")]
+[assembly: AssemblyVersion("0.4.1.1")]
+[assembly: AssemblyFileVersion("0.4.1.1")]

--- a/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
+++ b/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
@@ -221,8 +221,15 @@ namespace SharpBucket.V2.EndPoints{
 
         #region Commits Resource
 
-        internal CommitInfo ListCommits(string accountName, string repository){
+        internal CommitInfo ListCommits(string accountName, string repository, string branchortag = null )
+        {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "commits/");
+
+            if ( !string.IsNullOrEmpty( branchortag ))
+            {
+                overrideUrl += branchortag;
+            }
+
             return _sharpBucketV2.Get(new CommitInfo(), overrideUrl);
         }
 

--- a/SharpBucket/V2/EndPoints/RepositoryResource.cs
+++ b/SharpBucket/V2/EndPoints/RepositoryResource.cs
@@ -155,9 +155,11 @@ namespace SharpBucket.V2.EndPoints{
         /// Gets the commit information associated with a repository. 
         /// By default, this call returns all the commits across all branches, bookmarks, and tags. The newest commit is first. 
         /// </summary>
+        /// <param name="branchortag">The branch or tag to get, for example, master or default.</param>
         /// <returns></returns>
-        public object ListCommits(){
-            return _repositoriesEndPoint.ListCommits(_accountName, _repository);
+        public object ListCommits(string branchortag = null)
+        {
+            return _repositoriesEndPoint.ListCommits(_accountName, _repository, branchortag);
         }
 
         /// <summary>


### PR DESCRIPTION
This allows to isolate a branch so that you get only the commits that exist on a single branch, as suggested in Atlassian's documentation,

[GET a commits list for a repository or compare commits across branches](https://confluence.atlassian.com/display/BITBUCKET/commits+or+commit+Resource#commitsorcommitResource-GETacommitslistforarepositoryorcomparecommitsacrossbranches)