### PR TITLE
Add the api calls for getting the src and raw data of a revision

### DIFF
--- a/SharpBucket/Authentication/RequestExecutor.cs
+++ b/SharpBucket/Authentication/RequestExecutor.cs
@@ -9,11 +9,20 @@ namespace SharpBucket.Authentication{
                 request.AddObject(body);
             }
             var result = client.Execute<T>(request);
+            // This is a hack in order to allow this method to work for simple types as well
+            // one example of this is the GetRevisionRaw method
+            if (RequestingSimpleType<T>()){
+              return result.Content as dynamic;
+            }
             return result.Data;
         }
 
-        private static bool ShouldAddBody(Method method){
+       private static bool ShouldAddBody(Method method){
             return method == Method.PUT || method == Method.POST;
-        }
+       }
+
+       private static bool RequestingSimpleType<T>() where T : new(){
+          return typeof(T) == typeof(object);
+       }
     }
 }

--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -31,6 +31,7 @@
     <DocumentationFile>bin\Release\SharpBucket.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -56,6 +57,7 @@
     <Compile Include="V1\Pocos\RepositoryPrivileges.cs" />
     <Compile Include="V1\Pocos\RepositoryPrivilegesUser.cs" />
     <Compile Include="V1\Pocos\RepositorySimple.cs" />
+    <Compile Include="V1\Pocos\Revision.cs" />
     <Compile Include="V2\EndPoints\EndPoint.cs" />
     <Compile Include="V2\EndPoints\PullRequestResource.cs" />
     <Compile Include="V2\EndPoints\PullRequestsResource.cs" />

--- a/SharpBucket/V1/EndPoints/RepositoriesEndPoint.cs
+++ b/SharpBucket/V1/EndPoints/RepositoriesEndPoint.cs
@@ -500,6 +500,32 @@ namespace SharpBucket.V1.EndPoints{
 
         #endregion
 
+        #region Revision Resource
+
+        /// <summary>
+        /// Lists the source files for a given revision and path.
+        /// </summary>
+        /// <param name="revision">Revision to get.</param>
+        /// <param name="path">File to get.</param>
+        /// <returns></returns>
+        public List<Revision> GetRevisionSrc(string revision, string path) {
+           var overrideUrl = _baserUrl + "src/" + revision + "/" + path;
+           return _sharpBucketV1.Get(new List<Revision>(), overrideUrl);
+        }
+
+        /// <summary>
+        /// Retrieves file contents. 
+        /// </summary>
+        /// <param name="revision">Revision to get.</param>
+        /// <param name="path">File to get.</param>
+        /// <returns></returns>
+        public String GetRevisionRaw(string revision, string path) {
+           var overrideUrl = _baserUrl + "raw/" + revision + "/" + path;
+           return _sharpBucketV1.Get(new object(), overrideUrl) as String;
+        }
+
+        #endregion
+
         #endregion
     }
 }

--- a/SharpBucket/V1/Pocos/Revision.cs
+++ b/SharpBucket/V1/Pocos/Revision.cs
@@ -1,0 +1,8 @@
+﻿namespace SharpBucket.V1.Pocos {
+   public class Revision {
+      public string node { get; set; }
+      public string path { get; set; }
+      public string data { get; set; }
+      public int size { get; set; }
+   }
+}


### PR DESCRIPTION
This required to enahnce the logic in ExecuteRequest class, since the raw output is just a string and the ExecuteRequest.

This closes #5.