### PR TITLE
Fixed 'value was either too large or too small for an int32' error on deserialization'

### DIFF
--- a/SharpBucket/V1/Pocos/BranchInfo.cs
+++ b/SharpBucket/V1/Pocos/BranchInfo.cs
@@ -13,6 +13,6 @@ namespace SharpBucket.V1.Pocos{
         public string branch { get; set; }
         public string message { get; set; }
         public object revision { get; set; }
-        public int? size { get; set; }
+        public ulong? size { get; set; }
     }
 }

--- a/SharpBucket/V1/Pocos/Changeset.cs
+++ b/SharpBucket/V1/Pocos/Changeset.cs
@@ -12,6 +12,6 @@ namespace SharpBucket.V1.Pocos{
         public string branch { get; set; }
         public string message { get; set; }
         public object revision { get; set; }
-        public int? size { get; set; }
+        public ulong? size { get; set; }
     }
 }

--- a/SharpBucket/V1/Pocos/Repository.cs
+++ b/SharpBucket/V1/Pocos/Repository.cs
@@ -9,7 +9,7 @@
         public string logo { get; set; }
         public string email_mailinglist { get; set; }
         public bool? is_mq { get; set; }
-        public int? size { get; set; }
+        public ulong? size { get; set; }
         public bool? read_only { get; set; }
         public object fork_of { get; set; }
         public object mq_of { get; set; }

--- a/SharpBucket/V1/Pocos/Tag.cs
+++ b/SharpBucket/V1/Pocos/Tag.cs
@@ -13,6 +13,6 @@ namespace SharpBucket.V1.Pocos{
         public string branch { get; set; }
         public string message { get; set; }
         public object revision { get; set; }
-        public int? size { get; set; }
+        public ulong? size { get; set; }
     }
 }

--- a/SharpBucket/V2/Pocos/Fork.cs
+++ b/SharpBucket/V2/Pocos/Fork.cs
@@ -12,7 +12,7 @@
         public bool? has_issues { get; set; }
         public Owner owner { get; set; }
         public string updated_on { get; set; }
-        public int? size { get; set; }
+        public ulong? size { get; set; }
         public bool? is_private { get; set; }
         public string name { get; set; }
     }

--- a/SharpBucket/V2/Pocos/IteratorBasedPage.cs
+++ b/SharpBucket/V2/Pocos/IteratorBasedPage.cs
@@ -9,6 +9,6 @@ namespace SharpBucket.V2.Pocos {
         public int? pagelen { get; set; }
         public string next { get; set; }
         public List<T> values { get; set; }
-        public int? size { get; set; }
+        public ulong? size { get; set; }
     }
 }

--- a/SharpBucket/V2/Pocos/Repository.cs
+++ b/SharpBucket/V2/Pocos/Repository.cs
@@ -11,7 +11,7 @@
         public bool? has_issues { get; set; }
         public Owner owner { get; set; }
         public string updated_on { get; set; }
-        public int? size { get; set; }
+        public ulong? size { get; set; }
         public bool? is_private { get; set; }
         public string name { get; set; }
     }

--- a/SharpBucket/V2/Pocos/TeamProfile.cs
+++ b/SharpBucket/V2/Pocos/TeamProfile.cs
@@ -5,6 +5,6 @@ namespace SharpBucket.V2.Pocos{
         public int? pagelen { get; set; }
         public List<Link> links { get; set; }
         public int? page { get; set; }
-        public int? size { get; set; }
+        public ulong? size { get; set; }
     }
 }


### PR DESCRIPTION
The `size` parameter of large resources was causing a System.OverflowException during deserialization. I changed the `size` property to `UInt64`.