### PR TITLE
Repositorycreationv2apiandresponseexamination

### DIFF
--- a/SharpBucket/Authentication/IAuthenticate.cs
+++ b/SharpBucket/Authentication/IAuthenticate.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using RestSharp;
 
@@ -9,6 +10,12 @@ namespace SharpBucket.Authentication{
             var executeMethod = typeof (RequestExecutor).GetMethod("ExecuteRequest");
             var generic = executeMethod.MakeGenericMethod(typeof (T));
             return (T) generic.Invoke(this, new object[]{url, method, body, client, requestParameters});
+        }
+
+        public virtual T GetAndExamineResponse<T>(string url, Method method, T body, Dictionary<string, object> requestParameters, Action<IRestResponseExaminer> onResponse) {
+            var executeMethod = typeof(RequestExecutor).GetMethod("ExecuteRequestAndExamineBody");
+            var generic = executeMethod.MakeGenericMethod(typeof(T));
+            return (T)generic.Invoke(this, new object[] { url, method, body, client, requestParameters, onResponse });
         }
     }
 }

--- a/SharpBucket/Authentication/IRestResponseExaminer.cs
+++ b/SharpBucket/Authentication/IRestResponseExaminer.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace SharpBucket.Authentication
+{    
+    public interface IRestResponseExaminer{
+        IRestResponseExaminer CollectHeaders(Action<string, object> collect);
+        IRestResponseExaminer CollectStatus(Action<int> status);
+        IRestResponseExaminer CollectBody(Action<string> status);
+    }
+}

--- a/SharpBucket/Authentication/RequestExecutor.cs
+++ b/SharpBucket/Authentication/RequestExecutor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using RestSharp;
 
@@ -28,7 +29,37 @@ namespace SharpBucket.Authentication{
             return result.Data;
         }
 
-       private static bool ShouldAddBody(Method method){
+        public static T ExecuteRequestAndExamineBody<T>(string url, Method method, T body, RestClient client, Dictionary<string, object> requestParameters, Action<IRestResponseExaminer> configureResponseExaminer) where T : new(){
+            var request = new RestRequest(url, method);
+            if (requestParameters != null){
+                foreach (var requestParameter in requestParameters){
+                    request.AddParameter(requestParameter.Key, requestParameter.Value);
+                }
+            }
+            if (ShouldAddBody(method)){
+                request.RequestFormat = DataFormat.Json;
+                request.AddObject(body);
+            }
+            var result = client.Execute<T>(request);
+            
+            var responseExaminerConfigurator = configureResponseExaminer ?? (r => { });
+
+            var responseExaminer = new RestClientRestResponseExaminer();
+            responseExaminerConfigurator(responseExaminer);
+            responseExaminer.ExamineResponse(result);
+            
+            if (result.ErrorException != null){
+                throw new WebException("REST client encountered an error: " + result.ErrorMessage, result.ErrorException);
+            }
+            // This is a hack in order to allow this method to work for simple types as well
+            // one example of this is the GetRevisionRaw method
+            if (RequestingSimpleType<T>()){
+                return result.Content as dynamic;
+            }
+            return result.Data;
+        }
+
+        private static bool ShouldAddBody(Method method){
             return method == Method.PUT || method == Method.POST;
        }
 

--- a/SharpBucket/Authentication/ResponseExaminer.cs
+++ b/SharpBucket/Authentication/ResponseExaminer.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace SharpBucket.Authentication
+{    
+    public sealed class ResponseExaminer {
+        public int StatusCode { get; private set; }
+        public string Body { get; private set; }
+
+        public static implicit operator Action<IRestResponseExaminer>(ResponseExaminer instance){
+             return r =>{
+                 r.CollectStatus(s => instance.StatusCode = s);
+                 r.CollectBody(b => instance.Body = b);
+             };
+         }
+    }
+}

--- a/SharpBucket/Authentication/RestClientRestResponseExaminer.cs
+++ b/SharpBucket/Authentication/RestClientRestResponseExaminer.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using RestSharp;
+
+namespace SharpBucket.Authentication
+{
+    public sealed class RestClientRestResponseExaminer : IRestResponseExaminer{
+
+        private readonly IRestResponse response;
+        
+        private List<Action<RestClientRestResponseExaminer>> responseActions = new List<Action<RestClientRestResponseExaminer>>();
+
+        private RestClientRestResponseExaminer(IRestResponse response){
+            this.response = response;
+        }
+
+        public RestClientRestResponseExaminer(){ }
+
+        public void ExamineResponse(IRestResponse requestToConfigure){
+            var instance = new RestClientRestResponseExaminer(requestToConfigure) { responseActions = responseActions };
+            instance.ExamineResponse();
+        }
+
+        private void ExamineResponse(){            
+            foreach (var configurator in responseActions){
+                configurator(this);
+            }
+        }
+
+        public IRestResponseExaminer CollectStatus(Action<int> status){
+            responseActions.Add(r =>{
+                status((int)r.response.StatusCode);
+            });
+            return this;
+        }
+
+        public IRestResponseExaminer CollectBody(Action<string> body){
+            responseActions.Add(r =>{
+                body(r.response.Content);
+            });
+            return this;
+        }
+
+        public IRestResponseExaminer CollectHeaders(Action<string, object> collect){
+            responseActions.Add(r =>{                
+                foreach (var h in r.response.Headers.Where(x => x.Type == ParameterType.HttpHeader)){
+                    collect(h.Name, h.Value);
+                }
+            });
+            return this;
+        }
+    }
+}

--- a/SharpBucket/SharpBucket.cs
+++ b/SharpBucket/SharpBucket.cs
@@ -99,12 +99,29 @@ namespace SharpBucket{
             return response;
         }
 
+        private T SendAndExamine<T>(T body, Method method, string overrideUrl = null, Dictionary<string, object> requestParameters = null, Action<IRestResponseExaminer> onResponse = null){
+            var relativeUrl = overrideUrl;
+            T response;
+            try {
+                response = authenticator.GetAndExamineResponse(relativeUrl, method, body, requestParameters, onResponse);
+            }
+            catch (WebException ex){
+                Console.WriteLine(ex.Message);
+                response = default(T);
+            }
+            return response;
+        }
+
         internal T Get<T>(T body, string overrideUrl, Dictionary<string, object> requestParameters = null){
             return Send(body, Method.GET, overrideUrl, requestParameters);
         }
 
         internal T Post<T>(T body, string overrideUrl){
             return Send(body, Method.POST, overrideUrl);
+        }
+
+        internal T PostAndExamine<T>(T body, string overrideUrl, Action<IRestResponseExaminer> onResponse){
+            return SendAndExamine(body, Method.POST, overrideUrl, onResponse: onResponse);
         }
 
         internal T Put<T>(T body, string overrideUrl){

--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -61,8 +61,14 @@
     <Compile Include="V1\Pocos\RepositorySimple.cs" />
     <Compile Include="V1\Pocos\Revision.cs" />
     <Compile Include="V2\EndPoints\EndPoint.cs" />
+    <Compile Include="V2\EndPoints\Extras\ApiWord.cs" />
+    <Compile Include="V2\EndPoints\Extras\ForkWord.cs" />
+    <Compile Include="V2\EndPoints\Extras\IRepositoriesCreationConfigurationExpressions.cs" />
+    <Compile Include="V2\EndPoints\Extras\RepositoriesCreationConfigurationExpressions.cs" />
+    <Compile Include="V2\EndPoints\Extras\SCMWord.cs" />
     <Compile Include="V2\EndPoints\PullRequestResource.cs" />
     <Compile Include="V2\EndPoints\PullRequestsResource.cs" />
+    <Compile Include="V2\EndPoints\RepositoriesEndPointMixins.cs" />
     <Compile Include="V2\EndPoints\RepositoryResource.cs" />
     <Compile Include="V2\Pocos\Author.cs" />
     <Compile Include="V2\Pocos\Branch.cs" />
@@ -76,6 +82,7 @@
     <Compile Include="V2\Pocos\Parent.cs" />
     <Compile Include="V2\Pocos\Activity.cs" />
     <Compile Include="V2\Pocos\ActivityInfo.cs" />
+    <Compile Include="V2\Pocos\RepositoryCreationParameters.cs" />
     <Compile Include="V2\Pocos\Update.cs" />
     <Compile Include="V2\Pocos\Comment.cs" />
     <Compile Include="V2\Pocos\CommentsInfo.cs" />

--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -44,11 +44,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Authentication\BasicAuthentication.cs" />
+    <Compile Include="Authentication\IRestResponseExaminer.cs" />
     <Compile Include="Authentication\OauthAuthentication.cs" />
     <Compile Include="Authentication\OAuthentication2Legged.cs" />
     <Compile Include="Authentication\OAuthentication3Legged.cs" />
     <Compile Include="Authentication\OAuthentication2.cs" />
     <Compile Include="Authentication\RequestExecutor.cs" />
+    <Compile Include="Authentication\ResponseExaminer.cs" />
+    <Compile Include="Authentication\RestClientRestResponseExaminer.cs" />
     <Compile Include="Authentication\Token.cs" />
     <Compile Include="V1\EndPoints\IssueResource.cs" />
     <Compile Include="V1\EndPoints\PrivilegesEndPoint.cs" />

--- a/SharpBucket/V2/EndPoints/Extras/ApiWord.cs
+++ b/SharpBucket/V2/EndPoints/Extras/ApiWord.cs
@@ -1,0 +1,16 @@
+namespace SharpBucket.V2.EndPoints.Extras
+{
+    public abstract class ApiWord
+    {
+        public string Name { get; protected set; }
+
+        protected ApiWord()
+        {
+        }
+
+        protected ApiWord(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/SharpBucket/V2/EndPoints/Extras/ForkWord.cs
+++ b/SharpBucket/V2/EndPoints/Extras/ForkWord.cs
@@ -1,0 +1,9 @@
+namespace SharpBucket.V2.EndPoints.Extras
+{
+    public class ForkWord : ApiWord
+    {
+        public static readonly ForkWord AllowForks = new ForkWord() {Name = "allow_forks"};
+        public static readonly ForkWord NoPublicForks = new ForkWord() { Name = "no_public_forks" };
+        public static readonly ForkWord NoForks = new ForkWord() { Name = "no_forks" };
+    }
+}

--- a/SharpBucket/V2/EndPoints/Extras/IRepositoriesCreationConfigurationExpressions.cs
+++ b/SharpBucket/V2/EndPoints/Extras/IRepositoriesCreationConfigurationExpressions.cs
@@ -1,0 +1,13 @@
+namespace SharpBucket.V2.EndPoints.Extras
+{
+    public interface IRepositoriesCreationConfigurationExpressions
+    {        
+        IRepositoriesCreationConfigurationExpressions SetSCM(SCMWord scm);
+        IRepositoriesCreationConfigurationExpressions MakePrivate();
+        IRepositoriesCreationConfigurationExpressions SetDescription(string description);
+        IRepositoriesCreationConfigurationExpressions SetForkPolicy(ForkWord forkPolicy);
+        IRepositoriesCreationConfigurationExpressions SetLanguage(string language);
+        IRepositoriesCreationConfigurationExpressions EnableWiki();
+        IRepositoriesCreationConfigurationExpressions EnableIssues();
+    }
+}

--- a/SharpBucket/V2/EndPoints/Extras/RepositoriesCreationConfigurationExpressions.cs
+++ b/SharpBucket/V2/EndPoints/Extras/RepositoriesCreationConfigurationExpressions.cs
@@ -1,0 +1,56 @@
+using SharpBucket.V2.Pocos;
+
+namespace SharpBucket.V2.EndPoints.Extras
+{
+    public sealed class RepositoriesCreationConfigurationExpressions : IRepositoriesCreationConfigurationExpressions
+    {
+        private readonly RepositoryCreationParameters parameters;
+
+        public RepositoriesCreationConfigurationExpressions(RepositoryCreationParameters parameters)
+        {
+            this.parameters = parameters;
+        }
+
+        public IRepositoriesCreationConfigurationExpressions SetSCM(SCMWord scm)
+        {
+            parameters.scm = scm.Name;
+            return this;
+        }
+
+        public IRepositoriesCreationConfigurationExpressions MakePrivate()
+        {
+            parameters.is_private = true;
+            return this;
+        }
+
+        public IRepositoriesCreationConfigurationExpressions SetDescription(string description)
+        {
+            parameters.description = description;
+            return this;
+        }
+
+        public IRepositoriesCreationConfigurationExpressions SetForkPolicy(ForkWord forkPolicy)
+        {
+            parameters.fork_policy = forkPolicy.Name;
+            return this;
+        }
+
+        public IRepositoriesCreationConfigurationExpressions SetLanguage(string language)
+        {
+            parameters.language = language;
+            return this;
+        }
+
+        public IRepositoriesCreationConfigurationExpressions EnableWiki()
+        {
+            parameters.has_wiki = true;
+            return this;
+        }
+
+        public IRepositoriesCreationConfigurationExpressions EnableIssues()
+        {
+            parameters.has_issues = true;
+            return this;
+        }
+    }
+}

--- a/SharpBucket/V2/EndPoints/Extras/SCMWord.cs
+++ b/SharpBucket/V2/EndPoints/Extras/SCMWord.cs
@@ -1,0 +1,8 @@
+namespace SharpBucket.V2.EndPoints.Extras
+{
+    public class SCMWord : ApiWord
+    {
+        public static readonly SCMWord Git = new SCMWord() { Name = "git" };
+        public static readonly SCMWord Hg = new SCMWord() { Name = "hg" };
+    }
+}

--- a/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
+++ b/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
@@ -43,6 +43,19 @@ namespace SharpBucket.V2.EndPoints{
             return GetPaginatedValues<Repository>(_baseUrl, max);
         }
 
+        /// <summary>
+        /// Create repository under the provided accountName
+        /// </summary>
+        /// <param name="accountName">The owner of the repository.</param>
+        /// <param name="repository">The repository slug.</param>
+        /// <param name="configuration">Configuration parameters for repository creation. If not supplied, <see href="https://confluence.atlassian.com/bitbucket/repository-resource-423626331.html">defaults</see> are used</param>
+        /// <returns></returns>
+        public RepositoryResource CreateRepository(string accountName, string repository, RepositoryCreationParameters configuration = null)
+        {
+            PostRepository(accountName, repository, configuration ?? new RepositoryCreationParameters());
+            return new RepositoryResource(accountName, repository, this);
+        }
+
         #endregion
 
         #region Repository resource
@@ -80,6 +93,11 @@ namespace SharpBucket.V2.EndPoints{
             return string.Format(format, accountName, repository, append);
         }
 
+        private string GetRepositoryUrl(string accountName, string repository){
+            var format = _baseUrl + "{0}/{1}";
+            return string.Format(format, accountName, repository);
+        }
+
         internal List<Watcher> ListWatchers(string accountName, string repository, int max = 0){
             var overrideUrl = GetRepositoryUrl(accountName, repository, "watchers");
             return GetPaginatedValues<Watcher>(overrideUrl, max);
@@ -88,6 +106,11 @@ namespace SharpBucket.V2.EndPoints{
         internal List<Fork> ListForks(string accountName, string repository, int max = 0){
             var overrideUrl = GetRepositoryUrl(accountName, repository, "forks");
             return GetPaginatedValues<Fork>(overrideUrl, max);
+        }
+
+        internal RepositoryCreationParameters PostRepository(string accountName, string repository, RepositoryCreationParameters configuration){
+            var overrideUrl = GetRepositoryUrl(accountName, repository);
+            return _sharpBucketV2.Post(configuration, overrideUrl);
         }
 
         #endregion

--- a/SharpBucket/V2/EndPoints/RepositoriesEndPointMixins.cs
+++ b/SharpBucket/V2/EndPoints/RepositoriesEndPointMixins.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using SharpBucket.V2.EndPoints.Extras;
+using SharpBucket.V2.Pocos;
+
+namespace SharpBucket.V2.EndPoints
+{
+    public static class RepositoriesEndPointMixins
+    {
+        public static RepositoryResource CreateRepository(this RepositoriesEndPoint endpoint, string accountName,
+            string repository, Action<IRepositoriesCreationConfigurationExpressions> configureCreation)
+        {
+            var configurator = configureCreation ?? ((_) => { });            
+            var parameters = new RepositoryCreationParameters();
+            var configurationParameters = new RepositoriesCreationConfigurationExpressions(parameters);
+            configurator(configurationParameters);
+            return endpoint.CreateRepository(accountName, repository, parameters);
+        }
+    }
+}

--- a/SharpBucket/V2/EndPoints/RepositoriesEndPointMixins.cs
+++ b/SharpBucket/V2/EndPoints/RepositoriesEndPointMixins.cs
@@ -4,11 +4,9 @@ using SharpBucket.V2.Pocos;
 
 namespace SharpBucket.V2.EndPoints
 {
-    public static class RepositoriesEndPointMixins
-    {
+    public static class RepositoriesEndPointMixins{
         public static RepositoryResource CreateRepository(this RepositoriesEndPoint endpoint, string accountName,
-            string repository, Action<IRepositoriesCreationConfigurationExpressions> configureCreation)
-        {
+            string repository, Action<IRepositoriesCreationConfigurationExpressions> configureCreation){
             var configurator = configureCreation ?? ((_) => { });            
             var parameters = new RepositoryCreationParameters();
             var configurationParameters = new RepositoriesCreationConfigurationExpressions(parameters);

--- a/SharpBucket/V2/Pocos/RepositoryCreationParameters.cs
+++ b/SharpBucket/V2/Pocos/RepositoryCreationParameters.cs
@@ -1,7 +1,6 @@
 ﻿namespace SharpBucket.V2.Pocos
 {
-    public class RepositoryCreationParameters
-    {
+    public class RepositoryCreationParameters {
         public string scm { get; set; }
         public string name { get; set; }
         public bool is_private { get; set; }

--- a/SharpBucket/V2/Pocos/RepositoryCreationParameters.cs
+++ b/SharpBucket/V2/Pocos/RepositoryCreationParameters.cs
@@ -1,0 +1,14 @@
+﻿namespace SharpBucket.V2.Pocos
+{
+    public class RepositoryCreationParameters
+    {
+        public string scm { get; set; }
+        public string name { get; set; }
+        public bool is_private { get; set; }
+        public string description { get; set; }
+        public string fork_policy { get; set; }
+        public string language { get; set; }
+        public bool has_issues { get; set; }
+        public bool has_wiki { get; set; }
+    }
+}

--- a/SharpBucketTests/SharpBucketTests.csproj
+++ b/SharpBucketTests/SharpBucketTests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Authentication\OAuthentication2Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestHelpers.cs" />
+    <Compile Include="V2\EndPoints\Extras\RepositoriesEndPointTests.cs" />
     <Compile Include="V2\EndPoints\RepositoriesEndPointTests.cs" />
     <Compile Include="V2\EndPoints\RepositoryResourceTests.cs" />
     <Compile Include="V2\EndPoints\TeamsEndPointTests.cs" />

--- a/SharpBucketTests/SharpBucketTests.csproj
+++ b/SharpBucketTests/SharpBucketTests.csproj
@@ -65,7 +65,7 @@
     <Compile Include="Authentication\OAuthentication2Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestHelpers.cs" />
-    <Compile Include="V2\EndPoints\Extras\RepositoriesEndPointTests.cs" />
+    <Compile Include="V2\EndPoints\Extras\RepositoriesEndPointMixinsTests.cs" />
     <Compile Include="V2\EndPoints\RepositoriesEndPointTests.cs" />
     <Compile Include="V2\EndPoints\RepositoryResourceTests.cs" />
     <Compile Include="V2\EndPoints\TeamsEndPointTests.cs" />

--- a/SharpBucketTests/TestHelpers.cs
+++ b/SharpBucketTests/TestHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using SharpBucket.V2;
 
@@ -37,6 +38,17 @@ namespace SharBucketTests{
             var sharpbucket = new SharpBucketV2();
             sharpbucket.OAuthentication2(consumerKey, consumerSecretKey);
             return sharpbucket;
+        }
+
+        internal static void SwallowException(Action actionToExecute){
+            try
+            {
+                actionToExecute();
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e);
+            }
         }
     }
 }

--- a/SharpBucketTests/TestHelpers.cs
+++ b/SharpBucketTests/TestHelpers.cs
@@ -24,7 +24,8 @@ namespace SharBucketTests{
             return sharpbucket;
         }
 
-        public static SharpBucketV2 GetV2ClientAuthenticatedWithOAuth(){
+        public static SharpBucketV2 GetV2ClientAuthenticatedWithOAuth()
+        {
             var consumerKey = Environment.GetEnvironmentVariable(SbConsumerKey);
             var consumerSecretKey = Environment.GetEnvironmentVariable(SbConsumerSecretKey);
             var sharpbucket = new SharpBucketV2();
@@ -41,12 +42,10 @@ namespace SharBucketTests{
         }
 
         internal static void SwallowException(Action actionToExecute){
-            try
-            {
+            try{
                 actionToExecute();
             }
-            catch (Exception e)
-            {
+            catch (Exception e){
                 Debug.WriteLine(e);
             }
         }

--- a/SharpBucketTests/V2/EndPoints/Extras/RepositoriesEndPointMixinsTests.cs
+++ b/SharpBucketTests/V2/EndPoints/Extras/RepositoriesEndPointMixinsTests.cs
@@ -18,11 +18,19 @@ namespace SharBucketTests.V2.EndPoints.Extras{
          repositoriesEndPoint = sharpBucket.RepositoriesEndPoint();
       }
 
-      [Test]
+        [Test]
+        public void CreatingRepositoryWithoutSufficientRightsThrows(){
+            var repositoryToCreate = Guid.NewGuid().ToString().Replace("-", string.Empty);
+
+            Assert.Throws<InvalidOperationException>(() => {                
+                    repositoriesEndPoint.CreateRepository("tutorials", repositoryToCreate);
+            });
+        }
+
+        [Test]
       public void CanCreatePrivateNonForkableCSharpRepository(){
          var repositoryToCreate = Guid.NewGuid().ToString().Replace("-", string.Empty);
-          var repositoryResource = repositoriesEndPoint.CreateRepository(ACCOUNT_NAME, repositoryToCreate, c =>
-          {
+          var repositoryResource = repositoriesEndPoint.CreateRepository(ACCOUNT_NAME, repositoryToCreate, c =>{
               c.MakePrivate();
               c.SetLanguage("c#");
               c.SetForkPolicy(ForkWord.NoForks);

--- a/SharpBucketTests/V2/EndPoints/Extras/RepositoriesEndPointTests.cs
+++ b/SharpBucketTests/V2/EndPoints/Extras/RepositoriesEndPointTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using NUnit.Framework;
+using SharpBucket.V2;
+using SharpBucket.V2.EndPoints;
+using SharpBucket.V2.EndPoints.Extras;
+using Shouldly;
+
+namespace SharBucketTests.V2.EndPoints.Extras{
+   [TestFixture]
+   internal class RepositoriesEndPointMixinsTests{
+      private SharpBucketV2 sharpBucket;
+      private RepositoriesEndPoint repositoriesEndPoint;
+      private const string ACCOUNT_NAME = "mirror";
+
+      [SetUp]
+      public void Init(){
+         sharpBucket = TestHelpers.GetV2ClientAuthenticatedWithOAuth(); 
+         repositoriesEndPoint = sharpBucket.RepositoriesEndPoint();
+      }
+
+      [Test]
+      public void CanCreatePrivateNonForkableCSharpRepository(){
+         var repositoryToCreate = Guid.NewGuid().ToString().Replace("-", string.Empty);
+          var repositoryResource = repositoriesEndPoint.CreateRepository(ACCOUNT_NAME, repositoryToCreate, c =>
+          {
+              c.MakePrivate();
+              c.SetLanguage("c#");
+              c.SetForkPolicy(ForkWord.NoForks);
+          });
+          var repositoryFromSut = repositoryResource.GetRepository();
+          repositoryFromSut.is_private.ShouldBe(true);
+          repositoryFromSut.fork_policy.ShouldBe("no_forks");
+          repositoryFromSut.language.ShouldBe("c#");
+
+          TestHelpers.SwallowException(() => repositoryResource.DeleteRepository());
+        }
+    }
+}

--- a/SharpBucketTests/V2/EndPoints/RepositoriesEndPointTests.cs
+++ b/SharpBucketTests/V2/EndPoints/RepositoriesEndPointTests.cs
@@ -34,14 +34,13 @@ namespace SharBucketTests.V2.EndPoints{
       }
         
         [Test]
-        public void PostRepository_CreatesAndReturns_Repository()
-        {
-            var repositoryToCreate = Guid.NewGuid().ToString().Replace("-", string.Empty);
-            var repositoryResource = repositoriesEndPoint.CreateRepository(ACCOUNT_NAME, repositoryToCreate);
-            var repositoryFromSut = repositoryResource.GetRepository();
-            repositoryFromSut.name.ShouldBe(repositoryToCreate);
+      public void PostRepository_CreatesAndReturns_Repository(){
+        var repositoryToCreate = Guid.NewGuid().ToString().Replace("-", string.Empty);
+        var repositoryResource = repositoriesEndPoint.CreateRepository(ACCOUNT_NAME, repositoryToCreate);
+        var repositoryFromSut = repositoryResource.GetRepository();
+        repositoryFromSut.name.ShouldBe(repositoryToCreate);
 
-            TestHelpers.SwallowException(() => repositoryResource.DeleteRepository());
-        }        
+        TestHelpers.SwallowException(() => repositoryResource.DeleteRepository());
+      }        
     }
 }

--- a/SharpBucketTests/V2/EndPoints/RepositoriesEndPointTests.cs
+++ b/SharpBucketTests/V2/EndPoints/RepositoriesEndPointTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using SharpBucket.V2;
 using SharpBucket.V2.EndPoints;
 using Shouldly;
@@ -8,6 +9,7 @@ namespace SharBucketTests.V2.EndPoints{
    internal class RepositoriesEndPointTests{
       private SharpBucketV2 sharpBucket;
       private RepositoriesEndPoint repositoriesEndPoint;
+      private const string ACCOUNT_NAME = "mirror";
 
       [SetUp]
       public void Init(){
@@ -30,5 +32,16 @@ namespace SharBucketTests.V2.EndPoints{
          publicRepositories.Count.ShouldBe(30);
          publicRepositories[5].full_name.ShouldBe("vetler/fhtmlmps");
       }
-   }
+        
+        [Test]
+        public void PostRepository_CreatesAndReturns_Repository()
+        {
+            var repositoryToCreate = Guid.NewGuid().ToString().Replace("-", string.Empty);
+            var repositoryResource = repositoriesEndPoint.CreateRepository(ACCOUNT_NAME, repositoryToCreate);
+            var repositoryFromSut = repositoryResource.GetRepository();
+            repositoryFromSut.name.ShouldBe(repositoryToCreate);
+
+            TestHelpers.SwallowException(() => repositoryResource.DeleteRepository());
+        }        
+    }
 }


### PR DESCRIPTION
Hi,
I created a new branch & PR that would enable endpoint methods to examine HTTP response status & body (this way repository creation can throw e.g. on 403 forbidden). RestSharp is currently abstracted away from the endpoints, so I assumed you would want to keep it that way. See if the changes fit your idea... if not, just throw the PR into a trashcan.