### PR TITLE
Fix for pagination on ListPullRequests

### DIFF
--- a/SharpBucket/V2/EndPoints/PullRequestsResource.cs
+++ b/SharpBucket/V2/EndPoints/PullRequestsResource.cs
@@ -24,8 +24,8 @@ namespace SharpBucket.V2.EndPoints{
       /// List all of a repository's open pull requests.
       /// </summary>
       /// <returns></returns>
-      public List<PullRequest> ListPullRequests(){
-         return _repositoriesEndPoint.ListPullRequests(_accountName, _repository);
+      public List<PullRequest> ListPullRequests(int max = 100){
+         return _repositoriesEndPoint.ListPullRequests(_accountName, _repository, max);
       }
 
       /// <summary>

--- a/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
+++ b/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
@@ -104,7 +104,7 @@ namespace SharpBucket.V2.EndPoints{
             return new PullRequestsResource(accountName, repository, this);
         }
 
-        internal List<PullRequest> ListPullRequests(string accountName, string repository, int max = 0) {
+        internal List<PullRequest> ListPullRequests(string accountName, string repository, int max = 100) {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "pullrequests/");
             return GetPaginatedValues<PullRequest>(overrideUrl, max);
         }

--- a/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
+++ b/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
@@ -104,7 +104,7 @@ namespace SharpBucket.V2.EndPoints{
             return new PullRequestsResource(accountName, repository, this);
         }
 
-        internal List<PullRequest> ListPullRequests(string accountName, string repository, int max = 100) {
+        internal List<PullRequest> ListPullRequests(string accountName, string repository, int max) {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "pullrequests/");
             return GetPaginatedValues<PullRequest>(overrideUrl, max);
         }


### PR DESCRIPTION
The internal method ListPullRequests was returning 0 results by default, and the public method ListPullRequests does not take an argument for the number of results. 