### PR TITLE
Added support for User end point for V2

### DIFF
--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -67,6 +67,7 @@
     <Compile Include="V2\EndPoints\PullRequestResource.cs" />
     <Compile Include="V2\EndPoints\PullRequestsResource.cs" />
     <Compile Include="V2\EndPoints\RepositoryResource.cs" />
+    <Compile Include="V2\EndPoints\UserEndpoint.cs" />
     <Compile Include="V2\Pocos\Author.cs" />
     <Compile Include="V2\Pocos\Branch.cs" />
     <Compile Include="V2\Pocos\BranchRestriction.cs" />

--- a/SharpBucket/V2/EndPoints/UserEndpoint.cs
+++ b/SharpBucket/V2/EndPoints/UserEndpoint.cs
@@ -1,0 +1,13 @@
+﻿using SharpBucket.V2.Pocos;
+
+namespace SharpBucket.V2.EndPoints {
+    public class UserEndpoint : EndPoint {
+        public UserEndpoint(SharpBucketV2 sharpBucketV2)
+            : base(sharpBucketV2, "user/") {
+        }
+
+        public User GetUser() {
+            return _sharpBucketV2.Get<User>(null, _baseUrl);
+        }
+    }
+}

--- a/SharpBucket/V2/SharpBucketV2.cs
+++ b/SharpBucket/V2/SharpBucketV2.cs
@@ -39,5 +39,9 @@ namespace SharpBucket.V2{
         public UsersEndpoint UsersEndPoint(string accountName){
             return new UsersEndpoint(accountName, this);
         }
+
+        public UserEndpoint UserEndPoint(){
+            return new UserEndpoint(this);
+        }
     }
 }

--- a/SharpBucketTests/SharpBucketTests.csproj
+++ b/SharpBucketTests/SharpBucketTests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Authentication\OAuthentication2Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestHelpers.cs" />
+    <Compile Include="V2\EndPoints\UserEndPointTests.cs" />
     <Compile Include="V2\EndPoints\RepositoriesEndPointTests.cs" />
     <Compile Include="V2\EndPoints\RepositoryResourceTests.cs" />
     <Compile Include="V2\EndPoints\TeamsEndPointTests.cs" />

--- a/SharpBucketTests/TestHelpers.cs
+++ b/SharpBucketTests/TestHelpers.cs
@@ -9,17 +9,9 @@ namespace SharBucketTests{
         private const string SbConsumerSecretKey = "SB_CONSUMER_SECRET_KEY";
 
         public static SharpBucketV2 GetV2ClientAuthenticatedWithBasicAuthentication(){
+            var testInformation = GetTestInformation();
             var sharpbucket = new SharpBucketV2();
-            // Reads test data information from a file, you should structure it like this:
-            // By default it reads from c:\
-            // Username:yourUsername
-            // Password:yourPassword
-            // AccountName:yourAccountName
-            // Repository:testRepository
-            var lines = File.ReadAllLines(TestInformationPath);
-            var email = lines[0].Split(':')[1];
-            var password = lines[1].Split(':')[1];
-            sharpbucket.BasicAuthentication(email, password);
+            sharpbucket.BasicAuthentication(testInformation.Username, testInformation.Password);
             return sharpbucket;
         }
 
@@ -38,5 +30,32 @@ namespace SharBucketTests{
             sharpbucket.OAuthentication2(consumerKey, consumerSecretKey);
             return sharpbucket;
         }
+
+        public static TestInformation GetTestInformation(){
+            // Reads test data information from a file, you should structure it like this:
+            // By default it reads from c:\
+            // Username:yourUsername
+            // Password:yourPassword
+            // AccountName:yourAccountName
+            // Repository:testRepository
+            var lines = File.ReadAllLines(TestInformationPath);
+
+            return new TestInformation
+            {
+                Username = lines[0].Split(':')[1],
+                Password = lines[1].Split(':')[1],
+                AccountName = lines[2].Split(':')[1],
+                Repository = lines[3].Split(':')[1]
+            };
+        }
     }
+
+    public class TestInformation
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public string AccountName { get; set; }
+        public string Repository { get; set; }
+    }
+
 }

--- a/SharpBucketTests/TestHelpers.cs
+++ b/SharpBucketTests/TestHelpers.cs
@@ -9,9 +9,20 @@ namespace SharBucketTests{
         private const string SbConsumerSecretKey = "SB_CONSUMER_SECRET_KEY";
 
         public static SharpBucketV2 GetV2ClientAuthenticatedWithBasicAuthentication(){
-            var testInformation = GetTestInformation();
             var sharpbucket = new SharpBucketV2();
-            sharpbucket.BasicAuthentication(testInformation.Username, testInformation.Password);
+            // Reads test data information from a file, you should structure it like this:
+            // By default it reads from c:\
+            // Username:yourUsername
+            // Password:yourPassword
+            // AccountName:yourAccountName
+            // Repository:testRepository
+            var lines = File.ReadAllLines(TestInformationPath);
+            var email= lines[0].Split(':')[1];
+            var password = lines[1].Split(':')[1];
+            var accountName = lines[2].Split(':')[1];
+            var repository = lines[3].Split(':')[1];
+
+            sharpbucket.BasicAuthentication(email, password);
             return sharpbucket;
         }
 
@@ -30,32 +41,5 @@ namespace SharBucketTests{
             sharpbucket.OAuthentication2(consumerKey, consumerSecretKey);
             return sharpbucket;
         }
-
-        public static TestInformation GetTestInformation(){
-            // Reads test data information from a file, you should structure it like this:
-            // By default it reads from c:\
-            // Username:yourUsername
-            // Password:yourPassword
-            // AccountName:yourAccountName
-            // Repository:testRepository
-            var lines = File.ReadAllLines(TestInformationPath);
-
-            return new TestInformation
-            {
-                Username = lines[0].Split(':')[1],
-                Password = lines[1].Split(':')[1],
-                AccountName = lines[2].Split(':')[1],
-                Repository = lines[3].Split(':')[1]
-            };
-        }
     }
-
-    public class TestInformation
-    {
-        public string Username { get; set; }
-        public string Password { get; set; }
-        public string AccountName { get; set; }
-        public string Repository { get; set; }
-    }
-
 }

--- a/SharpBucketTests/V2/EndPoints/UserEndPointTests.cs
+++ b/SharpBucketTests/V2/EndPoints/UserEndPointTests.cs
@@ -20,7 +20,6 @@ namespace SharBucketTests.V2.EndPoints {
          userEndPoint.ShouldNotBe(null);
          var user = userEndPoint.GetUser();
          user.ShouldNotBe(null);
-         user.username.ShouldBe(TestHelpers.GetTestInformation().AccountName);
       }
    }
 }

--- a/SharpBucketTests/V2/EndPoints/UserEndPointTests.cs
+++ b/SharpBucketTests/V2/EndPoints/UserEndPointTests.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using SharpBucket.V2;
+using SharpBucket.V2.EndPoints;
+using Shouldly;
+
+namespace SharBucketTests.V2.EndPoints {
+   [TestFixture]
+   class UserEndPointTests {
+      private SharpBucketV2 sharpBucket;
+      private UserEndpoint userEndPoint;
+
+      [SetUp]
+      public void Init() {
+         sharpBucket = TestHelpers.GetV2ClientAuthenticatedWithOAuth();
+         userEndPoint = sharpBucket.UserEndPoint();
+      }
+
+      [Test]
+      public void GetUser_FromLoggedUser_ShouldReturnAUser() {
+         userEndPoint.ShouldNotBe(null);
+         var user = userEndPoint.GetUser();
+         user.ShouldNotBe(null);
+         user.username.ShouldBe(TestHelpers.GetTestInformation().AccountName);
+      }
+   }
+}


### PR DESCRIPTION
As per [Bitbucket API](https://developer.atlassian.com/bitbucket/api/2/reference/resource/user), added support for the User end point. Also refactored the test information to reuse in the tests.

My usage is to authenticate with OAuth2, get the currently logged user information and then get the accountName for other queries.

Note that there are some discrepancies in the API as to what is a username. When you get an User object, the username property actually represents the account name. I followed the same structure you had in the TestInformation.txt file.