### PR TITLE
Added support for getting the current user's teams.

### DIFF
--- a/SharpBucket/Authentication/IAuthenticate.cs
+++ b/SharpBucket/Authentication/IAuthenticate.cs
@@ -5,8 +5,7 @@ namespace SharpBucket.Authentication{
     public abstract class Authenticate{
         protected RestClient client;
 
-        public virtual T GetResponse<T>(string url, Method method, T body, IDictionary<string, object> requestParameters)
-        {
+        public virtual T GetResponse<T>(string url, Method method, T body, IDictionary<string, object> requestParameters) {
             var executeMethod = typeof (RequestExecutor).GetMethod("ExecuteRequest");
             var generic = executeMethod.MakeGenericMethod(typeof (T));
             return (T) generic.Invoke(this, new object[]{url, method, body, client, requestParameters});

--- a/SharpBucket/Authentication/IAuthenticate.cs
+++ b/SharpBucket/Authentication/IAuthenticate.cs
@@ -5,7 +5,8 @@ namespace SharpBucket.Authentication{
     public abstract class Authenticate{
         protected RestClient client;
 
-        public virtual T GetResponse<T>(string url, Method method, T body, Dictionary<string, object> requestParameters) {
+        public virtual T GetResponse<T>(string url, Method method, T body, IDictionary<string, object> requestParameters)
+        {
             var executeMethod = typeof (RequestExecutor).GetMethod("ExecuteRequest");
             var generic = executeMethod.MakeGenericMethod(typeof (T));
             return (T) generic.Invoke(this, new object[]{url, method, body, client, requestParameters});

--- a/SharpBucket/Authentication/OAuthentication3Legged.cs
+++ b/SharpBucket/Authentication/OAuthentication3Legged.cs
@@ -29,7 +29,7 @@ namespace SharpBucket.Authentication{
             OauthTokenSecret = oauthTokenSecret;
         }
 
-        public override T GetResponse<T>(string url, Method method, T body, Dictionary<string, object> requestParameters){
+        public override T GetResponse<T>(string url, Method method, T body, IDictionary<string, object> requestParameters){
             if (client == null){
                 client = new RestClient(_baseUrl){
                     Authenticator = OAuth1Authenticator.ForProtectedResource(ConsumerKey, ConsumerSecret, OAuthToken, OauthTokenSecret)

--- a/SharpBucket/Authentication/RequestExecutor.cs
+++ b/SharpBucket/Authentication/RequestExecutor.cs
@@ -4,7 +4,7 @@ using RestSharp;
 
 namespace SharpBucket.Authentication{
     internal class RequestExecutor{
-        public static T ExecuteRequest<T>(string url, Method method, T body, RestClient client, Dictionary<string, object> requestParameters) where T : new(){
+        public static T ExecuteRequest<T>(string url, Method method, T body, RestClient client, IDictionary<string, object> requestParameters) where T : new(){
             var request = new RestRequest(url, method);
             if (requestParameters != null){
                 foreach (var requestParameter in requestParameters){

--- a/SharpBucket/SharpBucket.cs
+++ b/SharpBucket/SharpBucket.cs
@@ -87,7 +87,7 @@ namespace SharpBucket{
             return (OAuthentication2) authenticator;
         }
 
-        private T Send<T>(T body, Method method, string overrideUrl = null, Dictionary<string, object> requestParameters = null) {
+        private T Send<T>(T body, Method method, string overrideUrl = null, IDictionary<string, object> requestParameters = null) {
             var relativeUrl = overrideUrl;
             T response;
             try{

--- a/SharpBucket/Utility/ObjectToDictionaryHelper.cs
+++ b/SharpBucket/Utility/ObjectToDictionaryHelper.cs
@@ -5,8 +5,7 @@ using System.ComponentModel;
 namespace SharpBucket.Utility{
     public static class ObjectToDictionaryHelper{
         //http://stackoverflow.com/questions/11576886/how-to-convert-object-to-dictionarytkey-tvalue-in-c
-        public static IDictionary<string, object> ToDictionary(this object source)
-        {
+        public static IDictionary<string, object> ToDictionary(this object source) {
             var dictionary = source as IDictionary<string, object>;
             return dictionary ?? source.ToDictionary<object>();
         }

--- a/SharpBucket/Utility/ObjectToDictionaryHelper.cs
+++ b/SharpBucket/Utility/ObjectToDictionaryHelper.cs
@@ -1,18 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Dynamic;
-using System.Linq;
-using System.Text;
 
 namespace SharpBucket.Utility{
     public static class ObjectToDictionaryHelper{
         //http://stackoverflow.com/questions/11576886/how-to-convert-object-to-dictionarytkey-tvalue-in-c
-        public static Dictionary<string, object> ToDictionary(this object source){
-            if (source is ExpandoObject)
-                return new Dictionary<string, object>(source as ExpandoObject);
-
-            return source.ToDictionary<object>();
+        public static IDictionary<string, object> ToDictionary(this object source)
+        {
+            var dictionary = source as IDictionary<string, object>;
+            return dictionary ?? source.ToDictionary<object>();
         }
 
         public static Dictionary<string, T> ToDictionary<T>(this object source){

--- a/SharpBucket/V2/EndPoints/EndPoint.cs
+++ b/SharpBucket/V2/EndPoints/EndPoint.cs
@@ -22,13 +22,18 @@ namespace SharpBucket.V2.EndPoints {
         /// <typeparam name="TValue"></typeparam>
         /// <param name="overrideUrl"></param>
         /// <param name="pageLen"></param>
+        /// <param name="requestParameters"></param>
         /// <returns></returns>
-        private IEnumerable<List<TValue>> IteratePages<TValue>(string overrideUrl, int pageLen = DEFAULT_PAGE_LEN) {
+        private IEnumerable<List<TValue>> IteratePages<TValue>(string overrideUrl, int pageLen = DEFAULT_PAGE_LEN, IDictionary<string, object> requestParameters = null) {
             Debug.Assert(!String.IsNullOrEmpty(overrideUrl));
             Debug.Assert(!overrideUrl.Contains("?"));
 
-            dynamic requestParameters= new ExpandoObject();
-            requestParameters.pagelen = pageLen;
+            if (requestParameters == null)
+            {
+                requestParameters = new Dictionary<string, object>();
+            }
+
+            requestParameters["pagelen"] = pageLen;
 
             IteratorBasedPage<TValue> response;
             int page = 1;
@@ -38,7 +43,7 @@ namespace SharpBucket.V2.EndPoints {
 
                 yield return response.values;
                 
-                requestParameters.page = ++page;
+                requestParameters["page"] = ++page;
             } while (!String.IsNullOrEmpty(response.next));
         }
 
@@ -48,16 +53,17 @@ namespace SharpBucket.V2.EndPoints {
         /// <typeparam name="TValue">The type of the value.</typeparam>
         /// <param name="overrideUrl">The override URL.</param>
         /// <param name="max">Set to 0 for unlimited size.</param>
+        /// <param name="requestParameters"></param>
         /// <returns></returns>
         /// <exception cref="System.Net.WebException">Thrown when the server fails to respond.</exception>
-        protected List<TValue> GetPaginatedValues<TValue>(string overrideUrl, int max = 0) {
+        protected List<TValue> GetPaginatedValues<TValue>(string overrideUrl, int max = 0, IDictionary<string, object> requestParameters = null) {
             bool isMaxConstrained = max > 0;
 
             int pageLen = (isMaxConstrained && max < DEFAULT_PAGE_LEN) ? max : DEFAULT_PAGE_LEN;
 
             List<TValue> values = new List<TValue>();
 
-            foreach (var page in IteratePages<TValue>(overrideUrl, pageLen)) {
+            foreach (var page in IteratePages<TValue>(overrideUrl, pageLen, requestParameters)) {
                 if (page == null) { break; }
 
                 if (isMaxConstrained &&

--- a/SharpBucket/V2/EndPoints/TeamsEndPoint.cs
+++ b/SharpBucket/V2/EndPoints/TeamsEndPoint.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Dynamic;
 using SharpBucket.V2.Pocos;
 
 namespace SharpBucket.V2.EndPoints{
@@ -11,6 +12,14 @@ namespace SharpBucket.V2.EndPoints{
 
         public TeamsEndPoint(SharpBucketV2 sharpBucketV2, string teamName)
             : base(sharpBucketV2, "teams/" + teamName + "/") {
+        }
+
+        public List<Team> GetUserTeams(int max = 0)
+        {
+            dynamic parameters = new ExpandoObject();
+            parameters.role = "member";
+            return GetPaginatedValues<Team>("teams/", max, parameters);
+            //return _sharpBucketV2.Get<List<Team>>(null, "teams/", parameters);
         }
 
         /// <summary>

--- a/SharpBucket/V2/EndPoints/TeamsEndPoint.cs
+++ b/SharpBucket/V2/EndPoints/TeamsEndPoint.cs
@@ -14,8 +14,7 @@ namespace SharpBucket.V2.EndPoints{
             : base(sharpBucketV2, "teams/" + teamName + "/") {
         }
 
-        public List<Team> GetUserTeams(int max = 0)
-        {
+        public List<Team> GetUserTeams(int max = 0) {
             dynamic parameters = new ExpandoObject();
             parameters.role = "member";
             return GetPaginatedValues<Team>("teams/", max, parameters);

--- a/SharpBucketTests/V2/EndPoints/TeamsEndPointTests.cs
+++ b/SharpBucketTests/V2/EndPoints/TeamsEndPointTests.cs
@@ -39,5 +39,14 @@ namespace SharBucketTests.V2.EndPoints {
          followers.Count.ShouldBe(8);
          followers[0].display_name.ShouldBe("Hector Miuler Malpica Gallegos");
       }
-   }
+
+        [Test]
+        public void GetTeams_FromLoggedUser_ShouldReturnManyTeams()
+        {
+            teamsEndPoint.ShouldNotBe(null);
+            var teams = teamsEndPoint.GetUserTeams();
+            teams.Count.ShouldBeGreaterThan(0);
+        }
+
+    }
 }

--- a/SharpBucketTests/V2/EndPoints/TeamsEndPointTests.cs
+++ b/SharpBucketTests/V2/EndPoints/TeamsEndPointTests.cs
@@ -41,8 +41,7 @@ namespace SharBucketTests.V2.EndPoints {
       }
 
         [Test]
-        public void GetTeams_FromLoggedUser_ShouldReturnManyTeams()
-        {
+        public void GetTeams_FromLoggedUser_ShouldReturnManyTeams(){
             teamsEndPoint.ShouldNotBe(null);
             var teams = teamsEndPoint.GetUserTeams();
             teams.Count.ShouldBeGreaterThan(0);


### PR DESCRIPTION
Implemented several related changes:
- the current TeamsEndPoint forces a teamname in its constructor. This is incorrect, according to the [API](https://developer.atlassian.com/bitbucket/api/2/reference/resource/teams), as you can GET the current user's team from the base path. In order to avoid breaking changes, I just added the new method and override the url. However, if you only want the user's teams, the usage will be a bit strange (sharpBucket.TeamsEndPoint("some_irrelevant_string").GetUserTeams()), but it's probably the best tradeoff.
- this API endpoint returns a paginated result that also needs query parameters. This is now supported with an argument that defaults to null, as done in the other methods.
- this last change forced some changes in the methods from Dictionary<string, object> to IDictionary<string, object>
- given that ExpandoObject implements IDictionaryObject<string, object> I also refactored the ObjectToDictionaryHelper. If you passed a dictionary, it was adding all kinds of unrelated properties to the request. I don't think the source.ToDictionary<object>() (on line 11) will ever be used (or the whole helper, in fact), but I still left it there in case someone is using something other than dictionaries and dynamic objects to pass parameters.

Note: sorry for the granular PRs, but I'm just noticing what is missing for my case as I go along. Thanks