### PR TITLE
Added Groups end point for V1

### DIFF
--- a/SharpBucket/Authentication/RequestExecutor.cs
+++ b/SharpBucket/Authentication/RequestExecutor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net;
 using RestSharp;
+using RestSharp.Deserializers;
 
 namespace SharpBucket.Authentication{
     internal class RequestExecutor{
@@ -11,10 +12,17 @@ namespace SharpBucket.Authentication{
                     request.AddParameter(requestParameter.Key, requestParameter.Value);
                 }
             }
+
             if (ShouldAddBody(method)){
                 request.RequestFormat = DataFormat.Json;
                 request.AddObject(body);
             }
+
+            //Fixed bug that prevents RestClient for adding custom headers to the request
+            //https://stackoverflow.com/questions/22229393/why-is-restsharp-addheaderaccept-application-json-to-a-list-of-item
+
+            client.ClearHandlers();
+            client.AddHandler("application/json", new JsonDeserializer());
             var result = client.Execute<T>(request);
 
             if (result.ErrorException != null) {

--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -56,7 +56,7 @@
     <Compile Include="V1\EndPoints\IssueResource.cs" />
     <Compile Include="V1\EndPoints\PrivilegesEndPoint.cs" />
     <Compile Include="V1\Pocos\Followers.cs" />
-    <Compile Include="V1\Pocos\Groups.cs" />
+    <Compile Include="V1\Pocos\Group.cs" />
     <Compile Include="V1\Pocos\IssueSearchParameters.cs" />
     <Compile Include="V1\Pocos\Link.cs" />
     <Compile Include="V1\Pocos\LinkInfo.cs" />

--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -52,9 +52,11 @@
     <Compile Include="Authentication\RequestExecutor.cs" />
     <Compile Include="Authentication\Token.cs" />
     <Compile Include="Utility\ObjectToDictionaryHelper.cs" />
+    <Compile Include="V1\EndPoints\GroupsEndPoint.cs" />
     <Compile Include="V1\EndPoints\IssueResource.cs" />
     <Compile Include="V1\EndPoints\PrivilegesEndPoint.cs" />
     <Compile Include="V1\Pocos\Followers.cs" />
+    <Compile Include="V1\Pocos\Groups.cs" />
     <Compile Include="V1\Pocos\IssueSearchParameters.cs" />
     <Compile Include="V1\Pocos\Link.cs" />
     <Compile Include="V1\Pocos\LinkInfo.cs" />

--- a/SharpBucket/V1/EndPoints/GroupsEndPoint.cs
+++ b/SharpBucket/V1/EndPoints/GroupsEndPoint.cs
@@ -45,8 +45,8 @@ namespace SharpBucket.V1.EndPoints
         /// <param name="name">The name of the group</param>
         /// <returns></returns>
         public Group CreateGroup(string name) {
-
-            return null;
+            var group = new Group() { name = name };
+            return _sharpBucketV1.Post<Group>(group, _baseUrl);
         }
 
         /// <summary>
@@ -54,17 +54,19 @@ namespace SharpBucket.V1.EndPoints
         /// <param name="group_slug">The group's slug.</param>
         /// <returns></returns>
         public Group DeleteGroup(string group_slug) {
-
-            return null;
+            var overrideUrl = _baseUrl + group_slug;
+            var group = new Group() { slug = group_slug };
+            return _sharpBucketV1.Delete<Group>(group, overrideUrl);
         }
 
         /// <summary>
         /// Updates the specified group
-        /// <param name="group_slug">The group's slug.</param>
+        /// <param name="group_slug">The group's slug to be updated.</param>
+        /// <param name="group">The new group.</param>
         /// <returns></returns>
-        public Group UpdateGroup(string group_slug) {
-
-            return null;
+        public Group UpdateGroup(string group_slug, Group group) {
+            var overrideUrl = _baseUrl + group_slug;
+            return _sharpBucketV1.Put<Group>(group, overrideUrl);
         }
 
         /// <summary>
@@ -75,7 +77,8 @@ namespace SharpBucket.V1.EndPoints
         /// <returns></returns>
         public User AddMemberToGroup(string group_slug, string membername) {
             var overrideUrl = _baseUrl + group_slug + "/members/" + membername;
-            return null;
+            var member = new User() { username = membername };
+            return _sharpBucketV1.Put<User>(member, overrideUrl);
         }
 
         /// <summary>
@@ -96,8 +99,8 @@ namespace SharpBucket.V1.EndPoints
         /// <returns></returns>
         public User DeleteMemberFromGroup(string group_slug, string membername) {
             var overrideUrl = _baseUrl + group_slug + "/members/" + membername;
-
-            return null;
+            var member = new User() { username = membername };
+            return _sharpBucketV1.Delete<User>(member, overrideUrl);
         }
     }
 }

--- a/SharpBucket/V1/EndPoints/GroupsEndPoint.cs
+++ b/SharpBucket/V1/EndPoints/GroupsEndPoint.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using SharpBucket.V1.Pocos;
+
+namespace SharpBucket.V1.EndPoints
+{
+    /// <summary>
+    /// The groups endpoint provides functionality for querying information about user groups, 
+    /// creating new ones, updating memberships, and deleting them. Both individual and team accounts can define groups.
+    /// To manage group information on an individual account, the caller must authenticate with administrative rights on the account. 
+    /// More info here:
+    /// https://confluence.atlassian.com/bitbucket/groups-endpoint-296093143.html
+    /// </summary>
+
+    public class GroupsEndPoint {
+        private readonly string _baseUrl;
+        private readonly SharpBucketV1 _sharpBucketV1;
+
+        public GroupsEndPoint(string accountName, SharpBucketV1 sharpBucketV1) {
+            _sharpBucketV1 = sharpBucketV1;
+            _baseUrl = $"groups/{accountName}/";
+        }
+
+        /// <summary>
+        /// Get a list of all groups in an account. 
+        /// </summary>
+        /// <returns></returns>
+        public List<Group> ListGroups() {
+            return _sharpBucketV1.Get<List<Group>>(new List<Group>(), _baseUrl);
+        }
+
+        /// <summary>
+        /// Get the details of a group. 
+        /// </summary>
+        /// <param name="group_slug">The group's slug.</param>
+        /// <returns></returns>
+        public Group GetGroup(string group_slug) {
+            var overrideUrl = _baseUrl + group_slug;
+            return _sharpBucketV1.Get<Group>(new Group(), overrideUrl);
+        }
+
+        /// <summary>
+        /// Creates a new default group 
+        /// </summary>
+        /// <param name="name">The name of the group</param>
+        /// <returns></returns>
+        public Group CreateGroup(string name) {
+
+            return null;
+        }
+
+        /// <summary>
+        /// Deletes the specified group
+        /// <param name="group_slug">The group's slug.</param>
+        /// <returns></returns>
+        public Group DeleteGroup(string group_slug) {
+
+            return null;
+        }
+
+        /// <summary>
+        /// Updates the specified group
+        /// <param name="group_slug">The group's slug.</param>
+        /// <returns></returns>
+        public Group UpdateGroup(string group_slug) {
+
+            return null;
+        }
+
+        /// <summary>
+        /// Adds a member to a group
+        /// </summary>
+        /// <param name="group_slug">The group's slug</param>
+        /// <param name="membername">An individual account name. This can be an account name or the primary email address for the account</param>
+        /// <returns></returns>
+        public User AddMemberToGroup(string group_slug, string membername) {
+            var overrideUrl = _baseUrl + group_slug + "/members/" + membername;
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the membership for a group 
+        /// </summary>
+        /// <param name="group_slug">The group's slug.</param>
+        /// <returns></returns>
+        public List<User> ListGroupMembers(string group_slug) {
+            var overrideUrl = _baseUrl + group_slug + "/members";
+            return _sharpBucketV1.Get<List<User>>(new List<User>(), overrideUrl);
+        }
+
+        /// <summary>
+        /// Adds a member to a group
+        /// </summary>
+        /// <param name="group_slug">The group's slug</param>
+        /// <param name="membername">An individual account name. This can be an account name or the primary email address for the account</param>
+        /// <returns></returns>
+        public User DeleteMemberFromGroup(string group_slug, string membername) {
+            var overrideUrl = _baseUrl + group_slug + "/members/" + membername;
+
+            return null;
+        }
+    }
+}

--- a/SharpBucket/V1/Pocos/Group.cs
+++ b/SharpBucket/V1/Pocos/Group.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace SharpBucket.V1.Pocos {
+    public class Group {
+
+        public string name { get; set; }
+        public string permission { get; set; }
+        public string auto_add { get; set; }
+        public List<User> members { get; set; }
+        public User owner { get; set; }
+        public string slug { get; set; }
+      
+    }
+}

--- a/SharpBucket/V1/SharpBucketV1.cs
+++ b/SharpBucket/V1/SharpBucketV1.cs
@@ -50,5 +50,18 @@ namespace SharpBucket.V1{
       public UsersEndPoint UsersEndPoint(string accountName){
          return new UsersEndPoint(accountName, this);
       }
-   }
+
+        /// <summary>
+        /// The groups endpoint provides functionality for querying information about user groups, 
+        /// creating new ones, updating memberships, and deleting them. Both individual and team accounts can define groups.
+        /// To manage group information on an individual account, the caller must authenticate with administrative rights on the account. 
+        /// More info:
+        /// https://confluence.atlassian.com/bitbucket/groups-endpoint-296093143.html
+        /// </summary>
+        public GroupsEndPoint GroupsEndPoint(string accountName) {
+            return new GroupsEndPoint(accountName, this);
+        }
+
+
+    }
 }

--- a/SharpBucketTests/SharpBucketTests.csproj
+++ b/SharpBucketTests/SharpBucketTests.csproj
@@ -65,6 +65,8 @@
     <Compile Include="Authentication\OAuthentication2Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestHelpers.cs" />
+    <Compile Include="V1\EndPoints\GroupsEndPointTests.cs" />
+    <Compile Include="V1\TestHelpers.cs" />
     <Compile Include="V2\EndPoints\UserEndPointTests.cs" />
     <Compile Include="V2\EndPoints\RepositoriesEndPointTests.cs" />
     <Compile Include="V2\EndPoints\RepositoryResourceTests.cs" />

--- a/SharpBucketTests/TestHelpers.cs
+++ b/SharpBucketTests/TestHelpers.cs
@@ -3,7 +3,7 @@ using System.IO;
 using SharpBucket.V2;
 
 namespace SharBucketTests{
-    internal class TestHelpers{
+    internal partial class TestHelpers{
         private const string TestInformationPath = "c:\\TestInformation.txt";
         private const string SbConsumerKey = "SB_CONSUMER_KEY";
         private const string SbConsumerSecretKey = "SB_CONSUMER_SECRET_KEY";

--- a/SharpBucketTests/V1/EndPoints/GroupsEndPointTests.cs
+++ b/SharpBucketTests/V1/EndPoints/GroupsEndPointTests.cs
@@ -19,12 +19,12 @@ namespace SharBucketTests.V1.EndPoints {
             groupsEndPoint = sharpBucket.GroupsEndPoint(ACCOUNT_NAME);
         }
 
-        [OneTimeTearDown]
-        public void Cleanup() {
-            groupsEndPoint.DeleteGroup("mygroup");
-            groupsEndPoint.DeleteGroup("admingroup");
-            groupsEndPoint.DeleteGroup("testgroup");
-        }
+        //[OneTimeTearDown]
+        //public void Cleanup() {
+        //    groupsEndPoint.DeleteGroup("mygroup");
+        //    groupsEndPoint.DeleteGroup("admingroup");
+        //    groupsEndPoint.DeleteGroup("testgroup");
+        //}
 
         [Test]
         [TestCase("MyGroup")]
@@ -57,6 +57,8 @@ namespace SharBucketTests.V1.EndPoints {
 
             var group = new Group() { name = "AdminGroup" };
             var new_group = groupsEndPoint.CreateGroup(group.name); //create a new group before adding a member to it
+
+            new_group.ShouldNotBe(null);
             var member = groupsEndPoint.AddMemberToGroup(new_group.slug, ACCOUNT_NAME);
 
             member.ShouldNotBe(null);
@@ -70,6 +72,8 @@ namespace SharBucketTests.V1.EndPoints {
 
             var group = new Group() { name = "TestGroup" };
             var new_group = groupsEndPoint.CreateGroup(group.name); //create a new group before 
+
+            new_group.ShouldNotBe(null);
             var member = groupsEndPoint.AddMemberToGroup(new_group.slug, ACCOUNT_NAME);
 
             var all_members = groupsEndPoint.ListGroupMembers(new_group.slug);

--- a/SharpBucketTests/V1/EndPoints/GroupsEndPointTests.cs
+++ b/SharpBucketTests/V1/EndPoints/GroupsEndPointTests.cs
@@ -19,6 +19,13 @@ namespace SharBucketTests.V1.EndPoints {
             groupsEndPoint = sharpBucket.GroupsEndPoint(ACCOUNT_NAME);
         }
 
+        [OneTimeTearDown]
+        public void Cleanup() {
+            groupsEndPoint.DeleteGroup("mygroup");
+            groupsEndPoint.DeleteGroup("admingroup");
+            groupsEndPoint.DeleteGroup("testgroup");
+        }
+
         [Test]
         [TestCase("MyGroup")]
         public void CreateGroup_ForLoggedUser_ShouldReturnCreatedGroup(string name) {
@@ -36,12 +43,11 @@ namespace SharBucketTests.V1.EndPoints {
 
         [Test]
         [TestCase("mygroup")]
-        public void DeleteGroup(string slug) {
+        public void DeleteGroup_ShouldNotHaveGroup_WhenGet(string slug) {
             groupsEndPoint.ShouldNotBe(null);
 
-            var group = groupsEndPoint.DeleteGroup(slug);
-
-            group = groupsEndPoint.GetGroup(slug);
+            groupsEndPoint.DeleteGroup(slug);
+            var group = groupsEndPoint.GetGroup(slug);
             group.ShouldBe(null);
         }
 

--- a/SharpBucketTests/V1/EndPoints/GroupsEndPointTests.cs
+++ b/SharpBucketTests/V1/EndPoints/GroupsEndPointTests.cs
@@ -1,0 +1,92 @@
+﻿using NUnit.Framework;
+using SharpBucket.V1;
+using SharpBucket.V1.EndPoints;
+using SharpBucket.V1.Pocos;
+using Shouldly;
+using System.Collections.Generic;
+
+namespace SharBucketTests.V1.EndPoints {
+    [TestFixture]
+    public class GroupsEndPointTests {
+
+        private SharpBucketV1 sharpBucket;
+        private GroupsEndPoint groupsEndPoint;
+        private const string ACCOUNT_NAME = "mxgod";
+
+        [SetUp]
+        public void Init() {
+            sharpBucket = TestHelpers.GetV1ClientAuthenticatedWithOAuth();
+            groupsEndPoint = sharpBucket.GroupsEndPoint(ACCOUNT_NAME);
+        }
+
+        [Test]
+        [TestCase("MyGroup")]
+        public IEnumerable<TestCaseData> CreateDefaultGroup_ForLoggedUser_ShouldReturnCreatedGroup(string name) {
+            groupsEndPoint.ShouldNotBe(null);
+
+            var group = groupsEndPoint.CreateGroup(name);
+
+            group.ShouldNotBe(null);
+            group.ShouldBeOfType(typeof(Group));
+            group.name.ShouldBe(name);
+            group.permission.ShouldBe(null); //test that a default group was created
+            group.members.Count.ShouldBe(0);  //test that a default group was created
+
+            return new List<TestCaseData>() { new TestCaseData(group, ACCOUNT_NAME) };
+        }
+
+        [Test]
+        [TestCaseSource("CreateDefaultGroup_ForLoggedUser_ShouldReturnCreatedGroup")]
+        public IEnumerable<TestCaseData> AddMemberToGroup_ShouldReturnAddedMember(Group group, string membername) {
+            groupsEndPoint.ShouldNotBe(null);
+
+            var member = groupsEndPoint.AddMemberToGroup(group.slug, membername);
+
+            member.ShouldNotBe(null);
+            member.ShouldBeOfType(typeof(User));
+            member.username.ShouldBe(membername);
+
+            return new List<TestCaseData>() { new TestCaseData(member, group.slug) };
+        }
+
+        [Test]
+        [TestCaseSource("AddMemberToGroup_ShouldReturnAddedMember")]
+        public void ListGroupMembers_ShouldCorrectlyListAllMembers(User member, string group_slug) {
+            groupsEndPoint.ShouldNotBe(null);
+
+            var all_members = groupsEndPoint.ListGroupMembers(group_slug);
+
+            all_members.ShouldNotBe(null);
+            all_members.ShouldBeOfType(typeof(List<User>));
+
+            all_members.ShouldContain<User>(member); //test the newly created member is listed
+        }
+
+       [Test]
+        public List<Group> ListAllGroups_FromLoggedUser_ShouldReturnAllGroups() {
+            groupsEndPoint.ShouldNotBe(null);
+
+            var groups = groupsEndPoint.ListGroups();
+
+            groups.ShouldNotBe(null);
+            groups.ShouldBeOfType<List<Group>>();
+            groups.Count.ShouldBeGreaterThan(0);
+            groups[0].name.ShouldNotBeEmpty();
+
+            return groups;
+        }
+
+        [Test, TestCaseSource("ListAllGroups_FromLoggedUser_ShouldReturnAllGroups")]
+        public void GetSingleGroup_FromLoggedUser_ShouldReturnSingleGroup(List<Group> groups) {
+            groupsEndPoint.ShouldNotBe(null);
+
+            var singleGroup = groupsEndPoint.GetGroup(groups[0].slug);
+
+            singleGroup.ShouldNotBe(null);
+            singleGroup.ShouldBeOfType(typeof(Group));
+            singleGroup.name.ShouldBe(groups[0].name);
+        }
+
+      
+    }
+}

--- a/SharpBucketTests/V1/EndPoints/GroupsEndPointTests.cs
+++ b/SharpBucketTests/V1/EndPoints/GroupsEndPointTests.cs
@@ -21,49 +21,50 @@ namespace SharBucketTests.V1.EndPoints {
 
         [Test]
         [TestCase("MyGroup")]
-        public IEnumerable<TestCaseData> CreateDefaultGroup_ForLoggedUser_ShouldReturnCreatedGroup(string name) {
+        public void CreateGroup_ForLoggedUser_ShouldReturnCreatedGroup(string name) {
             groupsEndPoint.ShouldNotBe(null);
 
             var group = groupsEndPoint.CreateGroup(name);
 
             group.ShouldNotBe(null);
             group.ShouldBeOfType(typeof(Group));
-            group.name.ShouldBe(name);
+            group.name.ShouldBe("MyGroup");
             group.permission.ShouldBe(null); //test that a default group was created
             group.members.Count.ShouldBe(0);  //test that a default group was created
 
-            return new List<TestCaseData>() { new TestCaseData(group, ACCOUNT_NAME) };
         }
 
         [Test]
-        [TestCaseSource("CreateDefaultGroup_ForLoggedUser_ShouldReturnCreatedGroup")]
-        public IEnumerable<TestCaseData> AddMemberToGroup_ShouldReturnAddedMember(Group group, string membername) {
+        public void AddMemberToGroup_ShouldReturnAddedMember() {
             groupsEndPoint.ShouldNotBe(null);
 
-            var member = groupsEndPoint.AddMemberToGroup(group.slug, membername);
+            var group = new Group() { name = "AdminGroup" };
+            var new_group = groupsEndPoint.CreateGroup(group.name); //create a new group before adding a member to it
+            var member = groupsEndPoint.AddMemberToGroup(new_group.slug, ACCOUNT_NAME);
 
             member.ShouldNotBe(null);
             member.ShouldBeOfType(typeof(User));
-            member.username.ShouldBe(membername);
-
-            return new List<TestCaseData>() { new TestCaseData(member, group.slug) };
+            member.username.ShouldBe(ACCOUNT_NAME);
         }
 
         [Test]
-        [TestCaseSource("AddMemberToGroup_ShouldReturnAddedMember")]
-        public void ListGroupMembers_ShouldCorrectlyListAllMembers(User member, string group_slug) {
+        public void ListGroupMembers_ShouldCorrectlyListAllMembers() {
             groupsEndPoint.ShouldNotBe(null);
 
-            var all_members = groupsEndPoint.ListGroupMembers(group_slug);
+            var group = new Group() { name = "TestGroup" };
+            var new_group = groupsEndPoint.CreateGroup(group.name); //create a new group before 
+            var member = groupsEndPoint.AddMemberToGroup(new_group.slug, ACCOUNT_NAME);
+
+            var all_members = groupsEndPoint.ListGroupMembers(new_group.slug);
 
             all_members.ShouldNotBe(null);
             all_members.ShouldBeOfType(typeof(List<User>));
-
-            all_members.ShouldContain<User>(member); //test the newly created member is listed
+            all_members.Count.ShouldBeGreaterThan(0);
+            all_members.Find(x => x.username == member.username).ShouldNotBe(null); //test the newly created member is listed
         }
 
        [Test]
-        public List<Group> ListAllGroups_FromLoggedUser_ShouldReturnAllGroups() {
+        public void ListAllGroups_FromLoggedUser_ShouldReturnAllGroups() {
             groupsEndPoint.ShouldNotBe(null);
 
             var groups = groupsEndPoint.ListGroups();
@@ -72,19 +73,17 @@ namespace SharBucketTests.V1.EndPoints {
             groups.ShouldBeOfType<List<Group>>();
             groups.Count.ShouldBeGreaterThan(0);
             groups[0].name.ShouldNotBeEmpty();
-
-            return groups;
         }
 
-        [Test, TestCaseSource("ListAllGroups_FromLoggedUser_ShouldReturnAllGroups")]
-        public void GetSingleGroup_FromLoggedUser_ShouldReturnSingleGroup(List<Group> groups) {
+        [Test]
+        public void GetSingleGroup_FromLoggedUser_ShouldReturnSingleGroup() {
             groupsEndPoint.ShouldNotBe(null);
 
-            var singleGroup = groupsEndPoint.GetGroup(groups[0].slug);
+            var singleGroup = groupsEndPoint.GetGroup("admingroup");
 
             singleGroup.ShouldNotBe(null);
             singleGroup.ShouldBeOfType(typeof(Group));
-            singleGroup.name.ShouldBe(groups[0].name);
+            singleGroup.name.ShouldBe("AdminGroup");
         }
 
       

--- a/SharpBucketTests/V1/EndPoints/GroupsEndPointTests.cs
+++ b/SharpBucketTests/V1/EndPoints/GroupsEndPointTests.cs
@@ -35,6 +35,17 @@ namespace SharBucketTests.V1.EndPoints {
         }
 
         [Test]
+        [TestCase("mygroup")]
+        public void DeleteGroup(string slug) {
+            groupsEndPoint.ShouldNotBe(null);
+
+            var group = groupsEndPoint.DeleteGroup(slug);
+
+            group = groupsEndPoint.GetGroup(slug);
+            group.ShouldBe(null);
+        }
+
+        [Test]
         public void AddMemberToGroup_ShouldReturnAddedMember() {
             groupsEndPoint.ShouldNotBe(null);
 

--- a/SharpBucketTests/V1/TestHelpers.cs
+++ b/SharpBucketTests/V1/TestHelpers.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using SharpBucket.V1;
+
+namespace SharBucketTests{
+    internal partial class TestHelpers{
+       
+        public static SharpBucketV1 GetV1ClientAuthenticatedWithOAuth(){
+
+            //get the environment variable from OS registry key for the current user
+            var consumerKey = Environment.GetEnvironmentVariable(SbConsumerKey, EnvironmentVariableTarget.User);
+            var consumerSecretKey = Environment.GetEnvironmentVariable(SbConsumerSecretKey, EnvironmentVariableTarget.User);
+
+            var sharpbucket = new SharpBucketV1();
+            sharpbucket.OAuth2LeggedAuthentication(consumerKey, consumerSecretKey);
+            return sharpbucket;
+        }
+
+    }
+}

--- a/SharpBucketTests/V1/TestHelpers.cs
+++ b/SharpBucketTests/V1/TestHelpers.cs
@@ -7,8 +7,8 @@ namespace SharBucketTests{
         public static SharpBucketV1 GetV1ClientAuthenticatedWithOAuth(){
 
             //get the environment variable from OS registry key for the current user
-            var consumerKey = Environment.GetEnvironmentVariable(SbConsumerKey, EnvironmentVariableTarget.User);
-            var consumerSecretKey = Environment.GetEnvironmentVariable(SbConsumerSecretKey, EnvironmentVariableTarget.User);
+            var consumerKey = Environment.GetEnvironmentVariable(SbConsumerKey);
+            var consumerSecretKey = Environment.GetEnvironmentVariable(SbConsumerSecretKey);
 
             var sharpbucket = new SharpBucketV1();
             sharpbucket.OAuth2LeggedAuthentication(consumerKey, consumerSecretKey);


### PR DESCRIPTION
Added support for [Bitbucket's Groups API](https://confluence.atlassian.com/bitbucket/groups-endpoint-296093143.html). 

Created V1 testing namespace and made __SharpBucketTests.TestHelpers.cs__ a partial class so that i can have  __TestHelpers.cs__ for V1 OAuth2 Authentication.

All actions on Bitbucket's Groups API has been catered for. Existing structure/convention were adhered. 