### PR TITLE
Add paging and limit support to DiffStat

### DIFF
--- a/SharpBucket/V1/EndPoints/RepositoriesEndPoint.cs
+++ b/SharpBucket/V1/EndPoints/RepositoriesEndPoint.cs
@@ -70,11 +70,13 @@ namespace SharpBucket.V1.EndPoints
         /// Private repositories require the caller to authenticate. 
         /// </summary>
         /// <param name="changeset">The change set whose diff stat you wish to get.</param>
+        /// <param name="limit">An integer representing how many changesets to return. You can specify a limit between 0 and 50.</param>
+        /// <param name="start">An integer representing the index of the file to start returning results from.</param>
         /// <returns></returns>
-        private List<DiffstatInfo> GetChangesetDiffstat(Changeset changeset)
+        private List<DiffstatInfo> GetChangesetDiffstat(Changeset changeset, int limit, int start)
         {
             var overrideUrl = _baserUrl + "changesets/" + changeset.node + "/diffstat/";
-            return _sharpBucketV1.Get(new List<DiffstatInfo>(), overrideUrl);
+            return _sharpBucketV1.Get(new List<DiffstatInfo>(), overrideUrl, new { limit, start });
         }
 
         /// <summary>
@@ -82,10 +84,12 @@ namespace SharpBucket.V1.EndPoints
         /// Private repositories require the caller to authenticate. 
         /// </summary>
         /// <param name="node">The node changeset identifier.</param>
+        /// <param name="limit">An integer representing how many changesets to return. You can specify a limit between 0 and 50.</param>
+        /// <param name="start">An integer representing the index of the file to start returning results from.</param>
         /// <returns></returns>
-        public List<DiffstatInfo> GetChangesetDiffstat(string node)
+        public List<DiffstatInfo> GetChangesetDiffstat(string node, int limit = 15, int start = 0)
         {
-            return GetChangesetDiffstat(new Changeset { node = node });
+            return GetChangesetDiffstat(new Changeset { node = node }, limit, start);
         }
 
         /// <summary>

--- a/SharpBucketTests/SharpBucketTests.csproj
+++ b/SharpBucketTests/SharpBucketTests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Authentication\OAuthentication2Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestHelpers.cs" />
+    <Compile Include="V1\EndPoints\ChangesetEndPointTests.cs" />
     <Compile Include="V1\EndPoints\GroupsEndPointTests.cs" />
     <Compile Include="V1\TestHelpers.cs" />
     <Compile Include="V2\EndPoints\UserEndPointTests.cs" />

--- a/SharpBucketTests/V1/EndPoints/ChangesetEndPointTests.cs
+++ b/SharpBucketTests/V1/EndPoints/ChangesetEndPointTests.cs
@@ -1,0 +1,66 @@
+﻿using NUnit.Framework;
+using SharpBucket.V1;
+using SharpBucket.V1.EndPoints;
+using Shouldly;
+using System;
+using System.Linq;
+
+namespace SharBucketTests.V1.EndPoints
+{
+    [TestFixture]
+    public class ChangesetEndPointTests
+    {
+        private SharpBucketV1 sharpBucket;
+        private RepositoriesEndPoint repositoriesEndPoint;
+        private string accountName;
+
+        private const string REPOSITORY_NAME = "mercurial";
+
+        [SetUp]
+        public void Init()
+        {
+            sharpBucket = TestHelpers.GetV1ClientAuthenticatedWithOAuth();
+            accountName = "mirror";
+            repositoriesEndPoint = sharpBucket.RepositoriesEndPoint(accountName, REPOSITORY_NAME);
+        }
+
+        [Test]
+        public void GetChangesetDiffstat_when_limit_is_specified_should_return_that_number_of_diffsets()
+        {
+            repositoriesEndPoint.ShouldNotBe(null);
+
+            var result = repositoriesEndPoint.ListChangeset();
+            result.ShouldNotBe(null);
+            result.changesets.Count.ShouldNotBe(0);
+
+            var commit = result.changesets.First();
+
+            var stats = repositoriesEndPoint.GetChangesetDiffstat(commit.node, 1);
+
+            stats.Count().ShouldBe(1);
+        }
+
+        [Test]
+        public void GetChangesetDiffstat_when_start_is_specified_should_return_from_that_index()
+        {
+            repositoriesEndPoint.ShouldNotBe(null);
+
+            var result = repositoriesEndPoint.ListChangeset();
+            result.ShouldNotBe(null);
+            result.changesets.Count.ShouldNotBe(0);
+
+            var commit = result.changesets.First();
+
+            var stats = repositoriesEndPoint.GetChangesetDiffstat(commit.node, 1);
+
+            var firstFile = stats.First().file;
+
+            stats = repositoriesEndPoint.GetChangesetDiffstat(commit.node, 1, 1);
+
+            var skippedFile = stats.First().file;
+
+            skippedFile.ShouldNotBe(firstFile);
+        }
+
+    }
+}


### PR DESCRIPTION
As discussed - fixed the line ending issue. 

This PR adds support for Paging and Limit on the DiffStat endpoint. This allows you to get more than 15 files by default.