### PR TITLE
Update return types on public classes

### DIFF
--- a/ConsoleTests/Program.cs
+++ b/ConsoleTests/Program.cs
@@ -242,11 +242,11 @@ namespace ConsoleTests
             var commitComments = repositoryResource.ListCommitComments(commitId);
             int commentId = 10;
             var commitComment = repositoryResource.GetCommitComment(commitId, commentId);
-            var commitApproval = repositoryResource.ApproveCommit(commitId);
-            var deleteApproval = repositoryResource.DeleteCommitApproval(commitId);
+            repositoryResource.ApproveCommit(commitId);
+            repositoryResource.DeleteCommitApproval(commitId);
 
             var targetUsername = "";
-            var defaultReviewer = repositoryResource.PutDefaultReviewer(targetUsername);
+            repositoryResource.PutDefaultReviewer(targetUsername);
 
             var r = repositoriesEndPoint.RepositoryResource(accountName, repository);
             var dr = r.DeleteRepository();
@@ -262,8 +262,8 @@ namespace ConsoleTests
             var commit2 = r.GetCommit(commitId);
             var commitComments2 = r.ListCommitComments(commitId);
             var commitComment2 = r.GetCommitComment(commitId, commentId);
-            var commitApproval2 = r.ApproveCommit(commitId);
-            var deleteApproval2 = r.DeleteCommitApproval(commitId);
+            r.ApproveCommit(commitId);
+            r.DeleteCommitApproval(commitId);
 
             var pullRequestsResource = r.PullRequestsResource();
             var pullRequests = pullRequestsResource.ListPullRequests();

--- a/ConsoleTests/Program.cs
+++ b/ConsoleTests/Program.cs
@@ -242,7 +242,7 @@ namespace ConsoleTests
             var commitComments = repositoryResource.ListCommitComments(commitId);
             int commentId = 10;
             var commitComment = repositoryResource.GetCommitComment(commitId, commentId);
-            repositoryResource.ApproveCommit(commitId);
+            var approveCommit = repositoryResource.ApproveCommit(commitId);
             repositoryResource.DeleteCommitApproval(commitId);
 
             var targetUsername = "";

--- a/SharpBucket/V2/EndPoints/PullRequestResource.cs
+++ b/SharpBucket/V2/EndPoints/PullRequestResource.cs
@@ -1,4 +1,7 @@
-﻿namespace SharpBucket.V2.EndPoints
+﻿using System.Collections.Generic;
+using SharpBucket.V2.Pocos;
+
+namespace SharpBucket.V2.EndPoints
 {
     /// <summary>
     /// A "Virtual" resource that offers easier manipulation of the pull request.
@@ -22,7 +25,7 @@
         /// List all the pull requests info for the repository.
         /// </summary>
         /// <returns></returns>
-        public object GetPullRequest()
+        public PullRequest GetPullRequest()
         {
             return _repositoriesEndPoint.GetPullRequest(_accountName, _repository, _pullRequestId);
         }
@@ -31,7 +34,7 @@
         /// List of the commits associated with a specific pull request, follow the pull request's commits link. This returns a paginated response.
         /// </summary>
         /// <returns></returns>
-        public object ListPullRequestCommits()
+        public List<Commit> ListPullRequestCommits()
         {
             return _repositoriesEndPoint.ListPullRequestCommits(_accountName, _repository, _pullRequestId);
         }
@@ -41,7 +44,7 @@
         /// This returns the participant object for the current user.
         /// </summary>
         /// <returns></returns>
-        public object ApprovePullRequest()
+        public PullRequestInfo ApprovePullRequest()
         {
             return _repositoriesEndPoint.ApprovePullRequest(_accountName, _repository, _pullRequestId);
         }
@@ -50,7 +53,7 @@
         /// Revoke your approval on a pull request. You can remove approvals on behalf of the authenticated account.
         /// </summary>
         /// <returns></returns>
-        public object RemovePullRequestApproval()
+        public PullRequestInfo RemovePullRequestApproval()
         {
             return _repositoriesEndPoint.RemovePullRequestApproval(_accountName, _repository, _pullRequestId);
         }
@@ -69,7 +72,7 @@
         /// Gets a log of the activity for a specific pull request.
         /// </summary>
         /// <returns></returns>
-        public object GetPullRequestActivity()
+        public List<Activity> GetPullRequestActivity()
         {
             return _repositoriesEndPoint.GetPullRequestActivity(_accountName, _repository, _pullRequestId);
         }
@@ -78,7 +81,7 @@
         /// Accept a pull request and merges into the destination branch. This requires write access on the destination repository.
         /// </summary>
         /// <returns></returns>
-        public object AcceptAndMergePullRequest()
+        public Merge AcceptAndMergePullRequest()
         {
             return _repositoriesEndPoint.AcceptAndMergePullRequest(_accountName, _repository, _pullRequestId);
         }
@@ -87,7 +90,7 @@
         /// Rejects a pull request. This requires write access on the destination repository.
         /// </summary>
         /// <returns></returns>
-        public object DeclinePullRequest()
+        public Merge DeclinePullRequest()
         {
             return _repositoriesEndPoint.DeclinePullRequest(_accountName, _repository, _pullRequestId);
         }
@@ -96,7 +99,7 @@
         /// List of comments on the specified pull request. 
         /// </summary>
         /// <returns></returns>
-        public object ListPullRequestComments()
+        public List<Comment> ListPullRequestComments()
         {
             return _repositoriesEndPoint.ListPullRequestComments(_accountName, _repository, _pullRequestId);
         }
@@ -105,7 +108,7 @@
         /// Gets an individual comment on an request. Private repositories require authorization with an account that has appropriate access.
         /// </summary>
         /// <param name="commentId">The comment identifier.</param>      /// <returns></returns>
-        public object GetPullRequestComment(int commentId)
+        public Comment GetPullRequestComment(int commentId)
         {
             return _repositoriesEndPoint.GetPullRequestComment(_accountName, _repository, _pullRequestId, commentId);
         }

--- a/SharpBucket/V2/EndPoints/PullRequestsResource.cs
+++ b/SharpBucket/V2/EndPoints/PullRequestsResource.cs
@@ -38,7 +38,7 @@ namespace SharpBucket.V2.EndPoints
         /// </summary>
         /// <param name="pullRequest">The pull request.</param>
         /// <returns></returns>
-        public object PostPullRequest(PullRequest pullRequest)
+        public PullRequest PostPullRequest(PullRequest pullRequest)
         {
             return _repositoriesEndPoint.PostPullRequest(_accountName, _repository, pullRequest);
         }
@@ -51,7 +51,7 @@ namespace SharpBucket.V2.EndPoints
         /// </summary>
         /// <param name="pullRequest">The pull request.</param>
         /// <returns></returns>
-        public object PutPullRequest(PullRequest pullRequest)
+        public PullRequest PutPullRequest(PullRequest pullRequest)
         {
             return _repositoriesEndPoint.PutPullRequest(_accountName, _repository, pullRequest);
         }
@@ -60,7 +60,7 @@ namespace SharpBucket.V2.EndPoints
         /// Returns all the pull request activity for a repository. This call returns a historical log of all the pull request activity within a repository.
         /// </summary>
         /// <returns></returns>
-        public object GetPullRequestLog()
+        public List<Activity> GetPullRequestLog()
         {
             return _repositoriesEndPoint.GetPullRequestLog(_accountName, _repository);
         }
@@ -81,22 +81,22 @@ namespace SharpBucket.V2.EndPoints
             return new PullRequestResource(_accountName, _repository, pullRequestId, _repositoriesEndPoint);
         }
 
-        internal object GetPullRequest(int pullRequestId)
+        internal PullRequest GetPullRequest(int pullRequestId)
         {
             return _repositoriesEndPoint.GetPullRequest(_accountName, _repository, pullRequestId);
         }
 
-        internal object ListPullRequestCommits(int pullRequestId)
+        internal List<Commit> ListPullRequestCommits(int pullRequestId)
         {
             return _repositoriesEndPoint.ListPullRequestCommits(_accountName, _repository, pullRequestId);
         }
 
-        internal object ApprovePullRequest(int pullRequestId)
+        internal PullRequestInfo ApprovePullRequest(int pullRequestId)
         {
             return _repositoriesEndPoint.ApprovePullRequest(_accountName, _repository, pullRequestId);
         }
 
-        internal object RemovePullRequestApproval(int pullRequestId)
+        internal PullRequestInfo RemovePullRequestApproval(int pullRequestId)
         {
             return _repositoriesEndPoint.RemovePullRequestApproval(_accountName, _repository, pullRequestId);
         }
@@ -106,27 +106,27 @@ namespace SharpBucket.V2.EndPoints
             return _repositoriesEndPoint.GetDiffForPullRequest(_accountName, _repository, pullRequestId);
         }
 
-        internal object GetPullRequestActivity(int pullRequestId)
+        internal List<Activity> GetPullRequestActivity(int pullRequestId)
         {
             return _repositoriesEndPoint.GetPullRequestActivity(_accountName, _repository, pullRequestId);
         }
 
-        internal object AcceptAndMergePullRequest(int pullRequestId)
+        internal Merge AcceptAndMergePullRequest(int pullRequestId)
         {
             return _repositoriesEndPoint.AcceptAndMergePullRequest(_accountName, _repository, pullRequestId);
         }
 
-        internal object DeclinePullRequest(int pullRequestId)
+        internal Merge DeclinePullRequest(int pullRequestId)
         {
             return _repositoriesEndPoint.DeclinePullRequest(_accountName, _repository, pullRequestId);
         }
 
-        internal object ListPullRequestComments(int pullRequestId)
+        internal List<Comment> ListPullRequestComments(int pullRequestId)
         {
             return _repositoriesEndPoint.ListPullRequestComments(_accountName, _repository, pullRequestId);
         }
 
-        internal object GetPullRequestComment(int pullRequestId, int commentId)
+        internal Comment GetPullRequestComment(int pullRequestId, int commentId)
         {
             return _repositoriesEndPoint.GetPullRequestComment(_accountName, _repository, pullRequestId, commentId);
         }

--- a/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
+++ b/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
@@ -162,7 +162,7 @@ namespace SharpBucket.V2.EndPoints
             return _sharpBucketV2.Post(new PullRequestInfo(), overrideUrl);
         }
 
-        internal object RemovePullRequestApproval(string accountName, string repository, int pullRequestId)
+        internal PullRequestInfo RemovePullRequestApproval(string accountName, string repository, int pullRequestId)
         {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "pullrequests/" + pullRequestId + "/approve/");
             return _sharpBucketV2.Delete(new PullRequestInfo(), overrideUrl);
@@ -280,25 +280,25 @@ namespace SharpBucket.V2.EndPoints
             return GetPaginatedValues<Comment>(overrideUrl, max);
         }
 
-        internal object GetCommitComment(string accountName, string repository, string revision, int commentId)
+        internal Comment GetCommitComment(string accountName, string repository, string revision, int commentId)
         {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "commits/" + revision + "/comments/" + revision + "/" + commentId + "/");
-            return _sharpBucketV2.Get(new object(), overrideUrl);
+            return _sharpBucketV2.Get(new Comment(), overrideUrl);
         }
 
-        internal object ApproveCommit(string accountName, string repository, string revision)
+        internal void ApproveCommit(string accountName, string repository, string revision)
         {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "commits/" + revision + "/approve/");
-            return _sharpBucketV2.Post(new object(), overrideUrl);
+            _sharpBucketV2.Post(new object(), overrideUrl);
         }
 
-        internal object DeleteCommitApproval(string accountName, string repository, string revision)
+        internal void DeleteCommitApproval(string accountName, string repository, string revision)
         {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "commits/" + revision + "/approve/");
-            return _sharpBucketV2.Delete(new object(), overrideUrl);
+            _sharpBucketV2.Delete(new object(), overrideUrl);
         }
 
-        internal object AddNewBuildStatus(string accountName, string repository, string revision, BuildInfo buildInfo)
+        internal BuildInfo AddNewBuildStatus(string accountName, string repository, string revision, BuildInfo buildInfo)
         {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "commit/" + revision + "/statuses/build/");
             return _sharpBucketV2.Post(buildInfo, overrideUrl);
@@ -310,7 +310,7 @@ namespace SharpBucket.V2.EndPoints
             return _sharpBucketV2.Get(new BuildInfo(), overrideUrl);
         }
 
-        internal object ChangeBuildStatusInfo(string accountName, string repository, string revision, string key, BuildInfo buildInfo)
+        internal BuildInfo ChangeBuildStatusInfo(string accountName, string repository, string revision, string key, BuildInfo buildInfo)
         {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "commit/" + revision + "/statuses/build/" + key);
             return _sharpBucketV2.Put(buildInfo, overrideUrl);
@@ -320,10 +320,10 @@ namespace SharpBucket.V2.EndPoints
 
         #region Default Reviewer Resource
 
-        internal object PutDefaultReviewer(string accountName, string repository, string targetUsername)
+        internal void PutDefaultReviewer(string accountName, string repository, string targetUsername)
         {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "default-reviewers/" + targetUsername);
-            return _sharpBucketV2.Put(new object(), overrideUrl);
+            _sharpBucketV2.Put(new object(), overrideUrl);
         }
 
         #endregion

--- a/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
+++ b/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
@@ -286,10 +286,10 @@ namespace SharpBucket.V2.EndPoints
             return _sharpBucketV2.Get(new Comment(), overrideUrl);
         }
 
-        internal void ApproveCommit(string accountName, string repository, string revision)
+        internal object ApproveCommit(string accountName, string repository, string revision)
         {
             var overrideUrl = GetRepositoryUrl(accountName, repository, "commits/" + revision + "/approve/");
-            _sharpBucketV2.Post(new object(), overrideUrl);
+            return _sharpBucketV2.Post(new object(), overrideUrl);
         }
 
         internal void DeleteCommitApproval(string accountName, string repository, string revision)

--- a/SharpBucket/V2/EndPoints/RepositoryResource.cs
+++ b/SharpBucket/V2/EndPoints/RepositoryResource.cs
@@ -220,7 +220,7 @@ namespace SharpBucket.V2.EndPoints
         /// </summary>
         /// <param name="revision">The commit's SHA1.</param>
         /// <returns></returns>
-        public void ApproveCommit(string revision)
+        public object ApproveCommit(string revision)
         {
             _repositoriesEndPoint.ApproveCommit(_accountName, _repository, revision);
         }

--- a/SharpBucket/V2/EndPoints/RepositoryResource.cs
+++ b/SharpBucket/V2/EndPoints/RepositoryResource.cs
@@ -222,7 +222,7 @@ namespace SharpBucket.V2.EndPoints
         /// <returns></returns>
         public object ApproveCommit(string revision)
         {
-            _repositoriesEndPoint.ApproveCommit(_accountName, _repository, revision);
+            return _repositoriesEndPoint.ApproveCommit(_accountName, _repository, revision);
         }
 
         /// <summary>

--- a/SharpBucket/V2/EndPoints/RepositoryResource.cs
+++ b/SharpBucket/V2/EndPoints/RepositoryResource.cs
@@ -94,7 +94,7 @@ namespace SharpBucket.V2.EndPoints
         /// List the information associated with a repository's branch restrictions. 
         /// </summary>
         /// <returns></returns>
-        public object ListBranchRestrictions()
+        public List<BranchRestriction> ListBranchRestrictions()
         {
             return _repositoriesEndPoint.ListBranchRestrictions(_accountName, _repository);
         }
@@ -114,7 +114,7 @@ namespace SharpBucket.V2.EndPoints
         /// </summary>
         /// <param name="restrictionId">The restriction's identifier.</param>
         /// <returns></returns>
-        public object GetBranchRestriction(int restrictionId)
+        public BranchRestriction GetBranchRestriction(int restrictionId)
         {
             return _repositoriesEndPoint.GetBranchRestriction(_accountName, _repository, restrictionId);
         }
@@ -134,7 +134,7 @@ namespace SharpBucket.V2.EndPoints
         /// </summary>
         /// <param name="restrictionId">The restriction's identifier.</param>
         /// <returns></returns>
-        public object DeleteBranchRestriction(int restrictionId)
+        public BranchRestriction DeleteBranchRestriction(int restrictionId)
         {
             return _repositoriesEndPoint.DeleteBranchRestriction(_accountName, _repository, restrictionId);
         }
@@ -209,7 +209,7 @@ namespace SharpBucket.V2.EndPoints
         /// <param name="revision">The commit's SHA1.</param>
         /// <param name="commentId">The comment identifier.</param>
         /// <returns></returns>
-        public object GetCommitComment(string revision, int commentId)
+        public Comment GetCommitComment(string revision, int commentId)
         {
             return _repositoriesEndPoint.GetCommitComment(_accountName, _repository, revision, commentId);
         }
@@ -220,9 +220,9 @@ namespace SharpBucket.V2.EndPoints
         /// </summary>
         /// <param name="revision">The commit's SHA1.</param>
         /// <returns></returns>
-        public object ApproveCommit(string revision)
+        public void ApproveCommit(string revision)
         {
-            return _repositoriesEndPoint.ApproveCommit(_accountName, _repository, revision);
+            _repositoriesEndPoint.ApproveCommit(_accountName, _repository, revision);
         }
 
         /// <summary>
@@ -230,9 +230,9 @@ namespace SharpBucket.V2.EndPoints
         /// </summary>
         /// <param name="revision">The commit's SHA1.</param>
         /// <returns></returns>
-        public object DeleteCommitApproval(string revision)
+        public void DeleteCommitApproval(string revision)
         {
-            return _repositoriesEndPoint.DeleteCommitApproval(_accountName, _repository, revision);
+            _repositoriesEndPoint.DeleteCommitApproval(_accountName, _repository, revision);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace SharpBucket.V2.EndPoints
         /// <param name="revision">The commit's SHA1</param>
         /// <param name="buildInfo">The new commit status object</param>
         /// <returns></returns>
-        public object AddNewBuildStatus(string revision, BuildInfo buildInfo)
+        public BuildInfo AddNewBuildStatus(string revision, BuildInfo buildInfo)
         {
             return _repositoriesEndPoint.AddNewBuildStatus(_accountName, _repository, revision, buildInfo);
         }
@@ -265,7 +265,7 @@ namespace SharpBucket.V2.EndPoints
         /// <param name="buildInfo">The new commit status object</param>
         /// <returns></returns>
         /// /// <remarks>This operation can also be used to change other properties of the build status: state, name, description, url, refname. The key cannot be changed.</remarks>
-        public object ChangeBuildStatusInfo(string revision, string key, BuildInfo buildInfo)
+        public BuildInfo ChangeBuildStatusInfo(string revision, string key, BuildInfo buildInfo)
         {
             return _repositoriesEndPoint.ChangeBuildStatusInfo(_accountName, _repository, revision, key, buildInfo);
         }
@@ -279,9 +279,9 @@ namespace SharpBucket.V2.EndPoints
         /// </summary>
         /// <param name="targetUsername">The user to add as the default reviewer.</param>
         /// <returns></returns>
-        public object PutDefaultReviewer(string targetUsername)
+        public void PutDefaultReviewer(string targetUsername)
         {
-            return _repositoriesEndPoint.PutDefaultReviewer(_accountName, _repository, targetUsername);
+            _repositoriesEndPoint.PutDefaultReviewer(_accountName, _repository, targetUsername);
         }
 
         #endregion


### PR DESCRIPTION
Simply updating the return types on classes that were previously returning object. 

I either checked against existing methods or the v2 API reference. 

I have intentionally not touched v1 as it will soon be removed by Bitbucket.