### PR TITLE
Fix ListMembers_FromTeamAtlassian_ShouldReturnManyMembers

### DIFF
--- a/SharpBucketTests/V2/EndPoints/TeamsEndPointTests.cs
+++ b/SharpBucketTests/V2/EndPoints/TeamsEndPointTests.cs
@@ -28,13 +28,17 @@ namespace SharBucketTests.V2.EndPoints
         }
 
         [Test]
-        public void ListMembers_FromTeamAtlassian_ShouldReturnManyMembers()
+        public void ListMembers_FromFirstTeamOfLoggedUser_ShouldReturnManyMembers()
         {
             teamsEndPoint.ShouldNotBe(null);
-            var members = teamsEndPoint.ListMembers(35);
-            members.Count.ShouldBeGreaterThan(19);
-            // This test is brittle, it should be updated since the names change
-            members[0].display_name.ShouldBe("Ivan Ostafiychuk");
+            var teams = teamsEndPoint.GetUserTeams();
+            teams.Count.ShouldBeGreaterThan(0);
+
+            var firstTeamEndPoint = sharpBucket.TeamsEndPoint(teams[0].username);
+            var members = firstTeamEndPoint.ListMembers(35);
+            members.Count.ShouldBeGreaterThan(0);
+            var userName = sharpBucket.UserEndPoint().GetUser().username;
+            members.ShouldContain(m => m.username == userName);
         }
 
         [Test]


### PR DESCRIPTION
Replace the ListMembers_FromTeamAtlassian_ShouldReturnManyMembers by ListMembers_FromFirstTeamOfLoggedUser_ShouldReturnManyMembers

listing the members of the team Atlassian is no more publicly accessible (probably an RGPD limitation)
To test the team members route we prefer to test on the members of the first team in which the logged user is.
This will ensure that we tests on a team on which we have some rights

Furthermore we have already the test GetTeams_FromLoggedUser_ShouldReturnManyTeams that require the logged user to be a member of at least one team, so it's a requirement that was already here.