### PR TITLE
Add slug, and make owner a POCO

### DIFF
--- a/SharpBucket/V2/Pocos/Repository.cs
+++ b/SharpBucket/V2/Pocos/Repository.cs
@@ -10,8 +10,9 @@
         public string language { get; set; }
         public string created_on { get; set; }
         public string full_name { get; set; }
+        public string slug { get; set; }
         public bool? has_issues { get; set; }
-        public string owner { get; set; }
+        public Owner owner { get; set; }
         public string updated_on { get; set; }
         public ulong? size { get; set; }
         public bool? is_private { get; set; }


### PR DESCRIPTION
The `slug` property was missing from `Repository`, and `owner` was defined as a string.