### PR TITLE
Get next page ID from next link

### DIFF
--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -42,6 +42,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Authentication\BasicAuthentication.cs" />

--- a/SharpBucket/V2/EndPoints/EndPoint.cs
+++ b/SharpBucket/V2/EndPoints/EndPoint.cs
@@ -2,7 +2,9 @@ using SharpBucket.V2.Pocos;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Web;
+
 
 namespace SharpBucket.V2.EndPoints
 {
@@ -33,6 +35,8 @@ namespace SharpBucket.V2.EndPoints
             Debug.Assert(!String.IsNullOrEmpty(overrideUrl));
             Debug.Assert(!overrideUrl.Contains("?"));
 
+            overrideUrl = overrideUrl.Replace(SharpBucketV2.BITBUCKET_URL, "");
+
             if (requestParameters == null)
             {
                 requestParameters = new Dictionary<string, object>();
@@ -42,21 +46,9 @@ namespace SharpBucket.V2.EndPoints
 
             IteratorBasedPage<TValue> response;
 
-            string GetNextPageID(string next)
+            while (true)
             {
-                if (String.IsNullOrWhiteSpace(next))
-                    return null;
-                else
-                {
-                    var uri = new Uri(response.next);
-                    var parsedQuery = HttpUtility.ParseQueryString(uri.Query);
-                    return parsedQuery["page"];
-                }
-            }
-
-            do
-            {
-                response = _sharpBucketV2.Get(new IteratorBasedPage<TValue>(), overrideUrl.Replace(SharpBucketV2.BITBUCKET_URL, ""), requestParameters);
+                response = _sharpBucketV2.Get(new IteratorBasedPage<TValue>(), overrideUrl, requestParameters);
                 if (response == null)
                 {
                     break;
@@ -64,9 +56,15 @@ namespace SharpBucket.V2.EndPoints
 
                 yield return response.values;
 
-                requestParameters["page"] = GetNextPageID(response.next);
+                if (String.IsNullOrWhiteSpace(response.next))
+                {
+                    break;
+                }
+
+                var uri = new Uri(response.next);
+                var parsedQuery = HttpUtility.ParseQueryString(uri.Query);
+                requestParameters = parsedQuery.AllKeys.ToDictionary<string, string, object>(key => key, parsedQuery.Get);                
             }
-            while (!String.IsNullOrEmpty(response.next));
         }
 
         /// <summary>


### PR DESCRIPTION
Get the next page identifier from the `next` link, instead of just incrementing an `int` counter.

Fixes #87 