### PR TITLE
Work with no authentication by default

### DIFF
--- a/SharpBucket/Authentication/NoAuthentication.cs
+++ b/SharpBucket/Authentication/NoAuthentication.cs
@@ -1,0 +1,12 @@
+﻿using RestSharp;
+
+namespace SharpBucket.Authentication
+{
+    public class NoAuthentication: Authenticate
+    {
+        public NoAuthentication(string baseUrl)
+        {
+            client = new RestClient(baseUrl);
+        }
+    }
+}

--- a/SharpBucket/SharpBucket.cs
+++ b/SharpBucket/SharpBucket.cs
@@ -27,6 +27,14 @@ namespace SharpBucket
         {
             this.BaseUrl = baseUrl;
             this.RequestExecutor = requestExecutor;
+            NoAuthentation();
+        }
+
+        /// <summary>
+        /// Do not use authentication with the BitBucket API. Only public data can be retrieved.
+        /// </summary>
+        public void NoAuthentation()
+        {
             authenticator = new NoAuthentication(BaseUrl) { RequestExecutor = this.RequestExecutor };
         }
 

--- a/SharpBucket/SharpBucket.cs
+++ b/SharpBucket/SharpBucket.cs
@@ -27,6 +27,7 @@ namespace SharpBucket
         {
             this.BaseUrl = baseUrl;
             this.RequestExecutor = requestExecutor;
+            authenticator = new NoAuthentication(BaseUrl);
         }
 
         /// <summary>   

--- a/SharpBucket/SharpBucket.cs
+++ b/SharpBucket/SharpBucket.cs
@@ -27,7 +27,7 @@ namespace SharpBucket
         {
             this.BaseUrl = baseUrl;
             this.RequestExecutor = requestExecutor;
-            authenticator = new NoAuthentication(BaseUrl);
+            authenticator = new NoAuthentication(BaseUrl) { RequestExecutor = this.RequestExecutor };
         }
 
         /// <summary>   

--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Authentication\BasicAuthentication.cs" />
+    <Compile Include="Authentication\NoAuthentication.cs" />
     <Compile Include="Authentication\OAuth2TokenProvider.cs" />
     <Compile Include="Authentication\OauthAuthentication.cs" />
     <Compile Include="Authentication\OAuthentication2Legged.cs" />

--- a/SharpBucketTests/Authentication/NoAuthenticationTests.cs
+++ b/SharpBucketTests/Authentication/NoAuthenticationTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SharpBucket.V2;
+using Shouldly;
+
+namespace SharpBucketTests.Authentication
+{
+    [TestFixture]
+    public class NoAuthenticationTests
+    {
+        [Test]
+        public void Client_WithNoAuth_ShouldRetrieveTortoise()
+        {
+            var client = new SharpBucketV2();
+            var ep = client.RepositoriesEndPoint();
+            var repo = ep.RepositoryResource("tortoisehg", "thg").GetRepository();
+
+            repo.ShouldNotBeNull();
+            repo.full_name.ShouldBe("tortoisehg/thg");
+        }
+
+        [Test]
+        public void Client_WithNoAuth_ShouldReadPublicRepos()
+        {
+            var client = new SharpBucketV2();
+            var ep = client.RepositoriesEndPoint();
+            var repos = ep.ListPublicRepositories(5);
+
+            repos.Count().ShouldBe(5);
+        }
+    }
+}

--- a/SharpBucketTests/SharpBucketTests.csproj
+++ b/SharpBucketTests/SharpBucketTests.csproj
@@ -68,6 +68,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="Authentication\NoAuthenticationTests.cs" />
     <Compile Include="Authentication\OAuthenticationTests.cs" />
     <Compile Include="Authentication\OAuthentication2Tests.cs" />
     <Compile Include="GitHelpers\IGitCredentialsProvider.cs" />


### PR DESCRIPTION
I should be able to use the library to call the API for public repositories without having to authenticate. Currently, if I don't call one of the authentication methods, `SharpBucket.authenticator` remains null, and then `Send()` will throw a `NullReferenceException`. So let's start by default with a `NoAuthentication` authenticator that instantiates a `RestClient` with no authentication.