### PR TITLE
Teach ParseSingleQuotedString() how to handle double quotes

### DIFF
--- a/SharpBucket/V2/EndPoints/FilterBuilder.cs
+++ b/SharpBucket/V2/EndPoints/FilterBuilder.cs
@@ -15,6 +15,7 @@ namespace SharpBucket.V2.EndPoints
         {
             if (input?.Contains("'") == true)
             {
+                input = input.Replace("\"", "\\\"");
                 var singleQuoteRegex = new Regex(@"''|'");
                 return singleQuoteRegex.Replace(input, m => m.Length == 2 ? "'" : "\"");
             }

--- a/SharpBucketTests/V2/EndPoints/FilterBuilderTests.cs
+++ b/SharpBucketTests/V2/EndPoints/FilterBuilderTests.cs
@@ -17,6 +17,8 @@ namespace SharpBucketTests.V2.EndPoints
         [TestCase("foo='bob''s burgers'", "foo=\"bob's burgers\"")]
         [TestCase("", "")]
         [TestCase(null, null)]
+        [TestCase("message = 'Need to test \"foo\"'", "message = \"Need to test \\\"foo\\\"\"")]
+        [TestCase(@"message = 'Need to test ""foo""'", "message = \"Need to test \\\"foo\\\"\"")]
         public void ParseSingleQuotedString_ForGivenInputAndExpected(string input, string expected)
         {
             var output = FilterBuilder.ParseSingleQuotedString(input);


### PR DESCRIPTION
https://github.com/MitjaBezensek/SharpBucket/issues/68#issuecomment-447864760 points out that the Bitbucket docs don't say how to escape double quotes in their filter language. I raised a ticket with them, and they say that they need to be escaped with a backslash. So this is correct:

```
q = message ~ "need to test \"foo\""
```
This PR teaches `ParseSingleQuotedString()` what to do with embedded double quotes. 

```csharp
var singleString = "message ~ 'Need to test \"foo\"'";
// or var singleString = @"message ~ 'Need to test ""foo""'";
var doubleString = FilterBuilder.ParseSingleQuotedString(singleString)
// doubleString == "message ~ \"Need to test \\\"foo\\\"\""
```
Since the goal of this helper method is to let the user avoid one level of escaping, I think it's appropriate to add this.