### PR TITLE
IRestClient and mocks

### DIFF
--- a/SharpBucket/Authentication/IAuthenticate.cs
+++ b/SharpBucket/Authentication/IAuthenticate.cs
@@ -6,7 +6,7 @@ namespace SharpBucket.Authentication
 {
     public abstract class Authenticate
     {
-        protected RestClient client;
+        protected IRestClient client;
 
         internal RequestExecutor RequestExecutor { get; set; } = new RequestExecutorV2(); // Use V2 by default since V1 should disappear soon
 

--- a/SharpBucket/Authentication/MockAuthentication.cs
+++ b/SharpBucket/Authentication/MockAuthentication.cs
@@ -1,0 +1,18 @@
+﻿using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpBucket.Authentication
+{
+    internal class MockAuthentication: Authenticate
+    {
+        public MockAuthentication(IRestClient client, string baseUrl)
+        {
+            client.BaseUrl = new Uri(baseUrl);
+            this.client = client;
+        }
+    }
+}

--- a/SharpBucket/Authentication/RequestExecutor.cs
+++ b/SharpBucket/Authentication/RequestExecutor.cs
@@ -8,7 +8,7 @@ namespace SharpBucket.Authentication
 {
     internal abstract class RequestExecutor
     {
-        public T ExecuteRequest<T>(string url, Method method, object body, RestClient client, IDictionary<string, object> requestParameters)
+        public T ExecuteRequest<T>(string url, Method method, object body, IRestClient client, IDictionary<string, object> requestParameters)
             where T : new()
         {
             var request = new RestRequest(url, method);
@@ -45,9 +45,9 @@ namespace SharpBucket.Authentication
             return result.Data;
         }
 
-        protected abstract void AddBody(RestRequest request, object body);
+        protected abstract void AddBody(IRestRequest request, object body);
 
-        private static IRestResponse<T> ExecuteRequest<T>(Method method, RestClient client, RestRequest request)
+        private static IRestResponse<T> ExecuteRequest<T>(Method method, IRestClient client, IRestRequest request)
             where T : new()
         {
             IRestResponse<T> result;

--- a/SharpBucket/SharpBucket.cs
+++ b/SharpBucket/SharpBucket.cs
@@ -114,6 +114,15 @@ namespace SharpBucket
             return (OAuthentication2)authenticator;
         }
 
+        /// <summary>
+        /// Allows the use of a mock IRestClient, for testing.
+        /// </summary>
+        /// <param name="client"></param>
+        internal void MockAuthentication(IRestClient client)
+        {
+            authenticator = new MockAuthentication(client, BaseUrl) { RequestExecutor = this.RequestExecutor };
+        }
+
         private T Send<T>(object body, Method method, string overrideUrl = null, IDictionary<string, object> requestParameters = null)
             where T : new()
         {

--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Authentication\BasicAuthentication.cs" />
+    <Compile Include="Authentication\MockAuthentication.cs" />
     <Compile Include="Authentication\OAuth2TokenProvider.cs" />
     <Compile Include="Authentication\OauthAuthentication.cs" />
     <Compile Include="Authentication\OAuthentication2Legged.cs" />

--- a/SharpBucket/V1/RequestExecutorV1.cs
+++ b/SharpBucket/V1/RequestExecutorV1.cs
@@ -5,7 +5,7 @@ namespace SharpBucket.V1
 {
     internal class RequestExecutorV1 : RequestExecutor
     {
-        protected override void AddBody(RestRequest request, object body)
+        protected override void AddBody(IRestRequest request, object body)
         {
             request.AddObject(body);
         }

--- a/SharpBucket/V2/RequestExecutorV2.cs
+++ b/SharpBucket/V2/RequestExecutorV2.cs
@@ -8,7 +8,7 @@ namespace SharpBucket.V2
 {
     internal class RequestExecutorV2 : RequestExecutor
     {
-        protected override void AddBody(RestRequest request, object body)
+        protected override void AddBody(IRestRequest request, object body)
         {
             // Use a custom JsonSerializerStrategy to be able to ignore null properties during the serialization
             // https://stackoverflow.com/questions/20006813/restsharp-how-to-skip-serializing-null-values-to-json

--- a/SharpBucketTests/Authentication/MockAuthenticationTests.cs
+++ b/SharpBucketTests/Authentication/MockAuthenticationTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Shouldly;
+using Moq;
+using RestSharp;
+using SharpBucket.V2;
+
+namespace SharpBucketTests.Authentication
+{
+    [TestFixture]
+    public class MockAuthenticationTests
+    {
+        private Mock<IRestClient> _client;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _client = new Mock<IRestClient>();
+        }
+
+        [Test]
+        public void Create_ShouldUseMock()
+        {
+            string expected = "Hello from mock";
+
+            _client.Setup(c => c.Execute<object>(It.IsAny<IRestRequest>()))
+                .Returns(new RestResponse<object>()
+                {
+                    ResponseStatus = ResponseStatus.Completed,
+                    StatusCode = System.Net.HttpStatusCode.OK,
+                    Content = expected,
+                });
+
+            var client = new SharpBucketV2();
+            client.MockAuthentication(_client.Object);
+            var output = client.Get(new object(), null);
+            output.ShouldBe(expected);
+        }
+    }
+}

--- a/SharpBucketTests/SharpBucketTests.csproj
+++ b/SharpBucketTests/SharpBucketTests.csproj
@@ -45,18 +45,34 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="LibGit2Sharp, Version=0.25.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
       <HintPath>..\packages\LibGit2Sharp.0.25.4\lib\netstandard2.0\LibGit2Sharp.dll</HintPath>
     </Reference>
+    <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.10.1\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="Shouldly, Version=2.8.3.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
       <HintPath>..\packages\Shouldly.2.8.3\lib\net451\Shouldly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -68,6 +84,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="Authentication\MockAuthenticationTests.cs" />
     <Compile Include="Authentication\OAuthenticationTests.cs" />
     <Compile Include="Authentication\OAuthentication2Tests.cs" />
     <Compile Include="GitHelpers\IGitCredentialsProvider.cs" />

--- a/SharpBucketTests/packages.config
+++ b/SharpBucketTests/packages.config
@@ -1,7 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.3.1" targetFramework="net461" />
   <package id="LibGit2Sharp" version="0.25.4" targetFramework="net461" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.252" targetFramework="net461" />
+  <package id="Moq" version="4.10.1" targetFramework="net461" />
   <package id="NUnit" version="3.9.0" targetFramework="net461" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net461" />
   <package id="Shouldly" version="2.8.3" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
In order to make unit testing easier, this PR changes method signatures in the library to use `IRestClient` instead of `RestClient`. This makes it possible, for example, to inject a mock `IRestClient` into `RequestExecutor.ExecuteRequest()`.

I also added a `MockAuthentication` object and method so that a mock `IRestClient` can be injected into the `SharpBucketV2` object from the beginning. 

This kind of unit testing will allow request construction and response parsing to be tested separately. For example, in the case of `ListParameters` and `DiffParameters`, I could now write a unit test to confirm that the methods generate the expected `IRestRequest`, without actually needing to hit Bitbucket to get a response.