### PR TITLE
IAsyncEnumerable

### DIFF
--- a/SharpBucket.sln
+++ b/SharpBucket.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2037
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29418.71
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpBucket", "SharpBucket\SharpBucket.csproj", "{F7C8FEF8-4ADB-4175-A4D8-2A0598B78786}"
 EndProject

--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Version>0.13.0</Version>
@@ -15,10 +16,17 @@
     <PackageTags>BitBucket REST API C#</PackageTags>
     <PackageReleaseNotes>https://github.com/MitjaBezensek/SharpBucket/releases/tag/$(Version)</PackageReleaseNotes>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <DefineConstants>$(DefineConstants);CS_8</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\LICENSE" Link="LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.3.1" />
   </ItemGroup>
+
 </Project>

--- a/SharpBucket/SharpBucket.csproj
+++ b/SharpBucket/SharpBucket.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Version>0.12.0</Version>
     <Authors>Mitja Bezenšek</Authors>
     <Company>Mitja Bezenšek</Company>

--- a/SharpBucket/V2/AsyncPaginatedListIterator.cs
+++ b/SharpBucket/V2/AsyncPaginatedListIterator.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_1
+﻿#if CS_8
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/SharpBucket/V2/AsyncPaginatedListIterator.cs
+++ b/SharpBucket/V2/AsyncPaginatedListIterator.cs
@@ -1,0 +1,93 @@
+﻿#if NETSTANDARD2_1
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Web;
+using SharpBucket.V2.Pocos;
+
+namespace SharpBucket.V2
+{
+    internal static class AsyncPaginatedListIterator
+    {
+        // vanilla page length in many cases is 10, requiring lots of requests for larger collections
+        private const int DEFAULT_PAGE_LEN = 50;
+
+        /// <summary>
+        /// Generator that allows lazy access to paginated resources.
+        /// </summary>
+        private static async IAsyncEnumerable<List<TValue>> IteratePagesAsync<TValue>(
+            SharpBucketV2 sharpBucketV2,
+            string overrideUrl,
+            int pageLen,
+            IDictionary<string, object> requestParameters,
+            [EnumeratorCancellation]CancellationToken token)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(overrideUrl));
+            Debug.Assert(!overrideUrl.Contains("?"));
+
+            overrideUrl = overrideUrl.Replace(SharpBucketV2.BITBUCKET_URL, "");
+
+            if (requestParameters == null)
+            {
+                requestParameters = new Dictionary<string, object>();
+            }
+
+            requestParameters["pagelen"] = pageLen;
+
+            while (true)
+            {
+                var response = await sharpBucketV2.GetAsync<IteratorBasedPage<TValue>>(overrideUrl, requestParameters, token: token);
+                if (response == null)
+                {
+                    break;
+                }
+
+                yield return response.values;
+
+                if (string.IsNullOrWhiteSpace(response.next))
+                {
+                    break;
+                }
+
+                var uri = new Uri(response.next);
+                var parsedQuery = HttpUtility.ParseQueryString(uri.Query);
+                requestParameters = parsedQuery.AllKeys.ToDictionary<string, string, object>(key => key, parsedQuery.Get);
+            }
+        }
+
+        /// <summary>
+        /// Returns an enumeration of paginated values. The pages are requested lazily while iterating on the values.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="sharpBucketV2"></param>
+        /// <param name="overrideUrl">The override URL.</param>
+        /// <param name="requestParameters"></param>
+        /// <param name="pageLen">The size of a page.</param>
+        /// <returns>A lazy enumerable over the values.</returns>
+        /// <exception cref="BitbucketV2Exception">Thrown when the server fails to respond.</exception>
+        public static async IAsyncEnumerable<TValue> EnumeratePaginatedValuesAsync<TValue>(
+            this SharpBucketV2 sharpBucketV2,
+            string overrideUrl,
+            IDictionary<string, object> requestParameters = null,
+            int? pageLen = null,
+            [EnumeratorCancellation]CancellationToken token = default)
+        {
+            await foreach (var page in IteratePagesAsync<TValue>(sharpBucketV2, overrideUrl, pageLen ?? DEFAULT_PAGE_LEN, requestParameters, token))
+            {
+                if (page == null)
+                {
+                    yield break;
+                }
+                foreach (var item in page)
+                {
+                    yield return item;
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
+++ b/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
@@ -139,6 +139,14 @@ namespace SharpBucket.V2.EndPoints
             return GetPaginatedValues<Repository>(overrideUrl, max);
         }
 
+#if NETSTANDARD2_1
+        internal IAsyncEnumerable<Repository> EnumerateForksAsync(string accountName, string slug, int? pageLen, CancellationToken token)
+        {
+            var overrideUrl = GetRepositoryUrl(accountName, slug, "forks");
+            return _sharpBucketV2.EnumeratePaginatedValuesAsync<Repository>(overrideUrl, pageLen: pageLen, token: token);
+        }
+#endif
+
         #endregion
 
         #region Pull Requests Resource

--- a/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
+++ b/SharpBucket/V2/EndPoints/RepositoriesEndPoint.cs
@@ -139,7 +139,7 @@ namespace SharpBucket.V2.EndPoints
             return GetPaginatedValues<Repository>(overrideUrl, max);
         }
 
-#if NETSTANDARD2_1
+#if CS_8
         internal IAsyncEnumerable<Repository> EnumerateForksAsync(string accountName, string slug, int? pageLen, CancellationToken token)
         {
             var overrideUrl = GetRepositoryUrl(accountName, slug, "forks");

--- a/SharpBucket/V2/EndPoints/RepositoryResource.cs
+++ b/SharpBucket/V2/EndPoints/RepositoryResource.cs
@@ -102,6 +102,17 @@ namespace SharpBucket.V2.EndPoints
             return _repositoriesEndPoint.ListForks(_accountName, _slug);
         }
 
+#if NETSTANDARD2_1
+        /// <summary>
+        /// Enumerate repository forks asynchronously, doing requests page by page.
+        /// This call returns a repository object for each fork.
+        /// </summary>
+        public IAsyncEnumerable<Repository> EnumerateForksAsync(int? pageLen = null, CancellationToken token = default)
+        {
+            return _repositoriesEndPoint.EnumerateForksAsync(_accountName, _slug, pageLen, token);
+        }
+#endif
+
         #endregion
 
         #region BranchResource

--- a/SharpBucket/V2/EndPoints/RepositoryResource.cs
+++ b/SharpBucket/V2/EndPoints/RepositoryResource.cs
@@ -102,7 +102,7 @@ namespace SharpBucket.V2.EndPoints
             return _repositoriesEndPoint.ListForks(_accountName, _slug);
         }
 
-#if NETSTANDARD2_1
+#if CS_8
         /// <summary>
         /// Enumerate repository forks asynchronously, doing requests page by page.
         /// This call returns a repository object for each fork.

--- a/SharpBucketTests/Authentication/RequestExecutorTests.cs
+++ b/SharpBucketTests/Authentication/RequestExecutorTests.cs
@@ -52,7 +52,7 @@ namespace SharpBucketTests.Authentication
                                 {"search_query", "string"},
                             }),
                 "Using a bad POCO should produce an Exception, but not a BitbucketException since it's not an issue detected by BitBucket, but an issue in our code.");
-            exception.Message.ShouldBe("No parameterless constructor defined for this object.");
+            exception.Message.ShouldBe("No parameterless constructor defined for type 'SharpBucket.V2.Pocos.SearchContentMatch[]'.");
         }
 
         private class FakeRequestExecutor : RequestExecutor

--- a/SharpBucketTests/SharpBucketTests.csproj
+++ b/SharpBucketTests/SharpBucketTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SharpBucketTests/V2/EndPoints/RepositoryResourceTests.cs
+++ b/SharpBucketTests/V2/EndPoints/RepositoryResourceTests.cs
@@ -80,6 +80,29 @@ namespace SharpBucketTests.V2.EndPoints
             }
         }
 
+        [Test]
+        public async Task EnumerateForksAsync_FromMercurialRepo_ShouldReturnMoreThan10UniqueForks()
+        {
+            var repositoryResource = SampleRepositories.MercurialRepository;
+            repositoryResource.ShouldNotBe(null);
+            var forks = repositoryResource.EnumerateForksAsync();
+            forks.ShouldNotBe(null);
+
+            var uniqueNames = new HashSet<string>();
+            await foreach (var fork in forks)
+            {
+                fork.ShouldBeFilled();
+
+                // since they are forks of mercurial, their parent should be mercurial
+                fork.parent.ShouldBeFilled();
+                fork.parent.name.ShouldBe(SampleRepositories.MERCURIAL_REPOSITORY_NAME);
+
+                uniqueNames.ShouldNotContain(fork.full_name);
+                uniqueNames.Add(fork.full_name);
+            }
+            uniqueNames.Count.ShouldBeGreaterThan(10);
+        }
+
         [TestCase(3)]
         [TestCase(103)]
         [Test]

--- a/SharpBucketTests/V2/EndPoints/SrcResourceTests.cs
+++ b/SharpBucketTests/V2/EndPoints/SrcResourceTests.cs
@@ -234,7 +234,7 @@ namespace SharpBucketTests.V2.EndPoints
 
             Assert.That(
                 () => rootOfFirstCommit.GetSrcFile(null),
-                Throws.TypeOf<ArgumentNullException>().With.Message.EndsWith("filePath"));
+                Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("filePath"));
         }
 
         [Test]


### PR DESCRIPTION
Doing a proper async implementation of EnumerateEntity methods require a C#8 feature

This PR probably could not be reintegrate right now (I expect CI to not run with a recent enough version of Visual Studio)

But the important thing to learn from that PR is that adding this feature won't need to add new async methods to the interfaces we expect to expose in #125 
So adding this later won't generate breaking change, so it's not a mandatory thing to do before doing #125 