### PR TITLE
changed naming of property Reviewers and Participants in PullRequest …

### DIFF
--- a/SharpBucket/V2/Pocos/PullRequest.cs
+++ b/SharpBucket/V2/Pocos/PullRequest.cs
@@ -19,7 +19,7 @@ namespace SharpBucket.V2.Pocos
         public DateTime updated_on { get; set; }
         public object merge_commit { get; set; }
         public int? id { get; set; }
-        public List<User> Reviewers { get; set; }
-        public List<UserRole> Participants { get; set; }
+        public List<User> reviewers { get; set; }
+        public List<UserRole> participants { get; set; }
     }
 }


### PR DESCRIPTION
I wasn't able to add reviewers to a pull request. 

When I examined this, it seemed that the properties of the Reviewers and Participants where with capitals and needed to be in lower casing.

After testing it with the lower casing, the reviewers were added to the Pull Request