### PR TITLE
Fixing tests for Linux

### DIFF
--- a/SharpBucketTests/GitHelpers/TestRepositoryBuilder.cs
+++ b/SharpBucketTests/GitHelpers/TestRepositoryBuilder.cs
@@ -108,9 +108,9 @@ namespace SharpBucketTests.GitHelpers
             var dir = Path.GetDirectoryName(fileName);
             if (!string.IsNullOrEmpty(dir))
             {
-                Directory.CreateDirectory($"{WorkingDirectory}\\{dir}");
+                Directory.CreateDirectory(Path.Combine(WorkingDirectory, dir));
             }
-            File.WriteAllText($"{WorkingDirectory}\\{fileName}", fileContent);
+            File.WriteAllText(Path.Combine(WorkingDirectory, fileName), fileContent);
             Commands.Stage(repository, fileName);
         }
 


### PR DESCRIPTION
Most of the tests fail on Linux because of the hardcoded path in filling the repo:
https://github.com/MitjaBezensek/SharpBucket/blob/96d068c6904ac104b136fd3fdfcaab08880794fc/SharpBucketTests/GitHelpers/TestRepositoryBuilder.cs#L111-L114

Path.Combine will make it cross platform.
